### PR TITLE
Migrate examples from rxros repository

### DIFF
--- a/brickpi3/CMakeLists.txt
+++ b/brickpi3/CMakeLists.txt
@@ -11,7 +11,6 @@ find_package(catkin REQUIRED
     brickpi3_msgs
     geometry_msgs
     nav_msgs
-    roscpp
     rxros
     sensor_msgs
     std_msgs
@@ -23,7 +22,6 @@ catkin_package(
     brickpi3_msgs
     geometry_msgs
     nav_msgs
-    roscpp
     rxros
     sensor_msgs
     std_msgs

--- a/brickpi3/CMakeLists.txt
+++ b/brickpi3/CMakeLists.txt
@@ -86,3 +86,17 @@ target_link_libraries(brickpi3_odom_publisher ${catkin_LIBRARIES})
 target_link_libraries(brickpi3_odom_publisher_rxros ${catkin_LIBRARIES})
 target_link_libraries(brickpi3_base_controller ${catkin_LIBRARIES})
 target_link_libraries(brickpi3_base_controller_rxros ${catkin_LIBRARIES})
+
+install(
+  TARGETS
+    brickpi3
+    brickpi3_base_controller
+    brickpi3_base_controller_rxros
+    brickpi3_joint_states_publisher
+    brickpi3_joint_states_publisher_rxros
+    brickpi3_odom_publisher
+    brickpi3_odom_publisher_rxros
+    brickpi3_rxros
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})

--- a/brickpi3/CMakeLists.txt
+++ b/brickpi3/CMakeLists.txt
@@ -1,0 +1,85 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(brickpi3)
+
+find_package(catkin REQUIRED
+  COMPONENTS
+    brickpi3_msgs
+    geometry_msgs
+    nav_msgs
+    roscpp
+    rxros
+    sensor_msgs
+    std_msgs
+    tf
+)
+
+catkin_package(
+  CATKIN_DEPENDS
+    brickpi3_msgs
+    geometry_msgs
+    nav_msgs
+    roscpp
+    rxros
+    sensor_msgs
+    std_msgs
+)
+
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+)
+
+add_executable(brickpi3
+  src/BrickPi3.cpp
+  src/BrickPi3Color.cpp
+  src/BrickPi3Motor.cpp
+  src/BrickPi3Ros.cpp
+  src/BrickPi3Touch.cpp
+  src/BrickPi3Ultrasonic.cpp
+)
+
+add_executable(brickpi3_rxros
+  src/BrickPi3.cpp
+  src/BrickPi3Ros_rx.cpp
+)
+
+add_executable(brickpi3_joint_states_publisher
+  src/BrickPi3JointStatesPublisher.cpp
+)
+
+add_executable(brickpi3_joint_states_publisher_rxros
+  src/BrickPi3JointStatesPublisher_rx.cpp
+)
+
+add_executable(brickpi3_odom_publisher
+  src/BrickPi3OdomPublisher.cpp
+)
+
+add_executable(brickpi3_odom_publisher_rxros
+  src/BrickPi3OdomPublisher_rx.cpp
+)
+
+add_executable(brickpi3_base_controller
+  src/BrickPi3BaseController.cpp
+)
+
+add_executable(brickpi3_base_controller_rxros
+  src/BrickPi3BaseController_rx.cpp
+)
+
+add_dependencies(brickpi3 ${catkin_EXPORTED_TARGETS})
+add_dependencies(brickpi3_rxros ${catkin_EXPORTED_TARGETS})
+add_dependencies(brickpi3_joint_states_publisher ${catkin_EXPORTED_TARGETS})
+add_dependencies(brickpi3_joint_states_publisher_rxros ${catkin_EXPORTED_TARGETS})
+add_dependencies(brickpi3_odom_publisher ${catkin_EXPORTED_TARGETS})
+add_dependencies(brickpi3_odom_publisher_rxros ${catkin_EXPORTED_TARGETS})
+add_dependencies(brickpi3_base_controller ${catkin_EXPORTED_TARGETS})
+add_dependencies(brickpi3_base_controller_rxros ${catkin_EXPORTED_TARGETS})
+
+target_link_libraries(brickpi3 ${catkin_LIBRARIES})
+target_link_libraries(brickpi3_rxros ${catkin_LIBRARIES})
+target_link_libraries(brickpi3_joint_states_publisher ${catkin_LIBRARIES})
+target_link_libraries(brickpi3_joint_states_publisher_rxros ${catkin_LIBRARIES})
+target_link_libraries(brickpi3_odom_publisher ${catkin_LIBRARIES})
+target_link_libraries(brickpi3_odom_publisher_rxros ${catkin_LIBRARIES})
+target_link_libraries(brickpi3_base_controller ${catkin_LIBRARIES})
+target_link_libraries(brickpi3_base_controller_rxros ${catkin_LIBRARIES})

--- a/brickpi3/CMakeLists.txt
+++ b/brickpi3/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(brickpi3)
 
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
 find_package(catkin REQUIRED
   COMPONENTS
     brickpi3_msgs

--- a/brickpi3/package.xml
+++ b/brickpi3/package.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>brickpi3</name>
+  <version>0.1.0</version>
+  <description>The RxROS brickpi3 package</description>
+
+  <maintainer email="wasowski@itu.dk">Andrzej Wasowski</maintainer>
+  <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn</maintainer>
+  <maintainer email="henrik7264@outlook.com">Henrik Larsen</maintainer>
+
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>brickpi3_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>nav_msgs</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>rxros</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>tf</build_depend>
+
+  <build_export_depend>brickpi3_msgs</build_export_depend>
+  <build_export_depend>geometry_msgs</build_export_depend>
+  <build_export_depend>nav_msgs</build_export_depend>
+  <build_export_depend>roscpp</build_export_depend>
+  <build_export_depend>rxros</build_export_depend>
+  <build_export_depend>sensor_msgs</build_export_depend>
+  <build_export_depend>std_msgs</build_export_depend>
+  <build_export_depend>tf</build_export_depend>
+
+  <exec_depend>brickpi3_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>nav_msgs</exec_depend>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>rxros</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>tf</exec_depend>
+</package>

--- a/brickpi3/package.xml
+++ b/brickpi3/package.xml
@@ -12,27 +12,11 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>brickpi3_msgs</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>nav_msgs</build_depend>
-  <build_depend>rxros</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>tf</build_depend>
-
-  <build_export_depend>brickpi3_msgs</build_export_depend>
-  <build_export_depend>geometry_msgs</build_export_depend>
-  <build_export_depend>nav_msgs</build_export_depend>
-  <build_export_depend>rxros</build_export_depend>
-  <build_export_depend>sensor_msgs</build_export_depend>
-  <build_export_depend>std_msgs</build_export_depend>
-  <build_export_depend>tf</build_export_depend>
-
-  <exec_depend>brickpi3_msgs</exec_depend>
-  <exec_depend>geometry_msgs</exec_depend>
-  <exec_depend>nav_msgs</exec_depend>
-  <exec_depend>rxros</exec_depend>
-  <exec_depend>sensor_msgs</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
-  <exec_depend>tf</exec_depend>
+  <depend>brickpi3_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>nav_msgs</depend>
+  <depend>rxros</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>tf</depend>
 </package>

--- a/brickpi3/package.xml
+++ b/brickpi3/package.xml
@@ -15,7 +15,6 @@
   <build_depend>brickpi3_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>nav_msgs</build_depend>
-  <build_depend>roscpp</build_depend>
   <build_depend>rxros</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
@@ -24,7 +23,6 @@
   <build_export_depend>brickpi3_msgs</build_export_depend>
   <build_export_depend>geometry_msgs</build_export_depend>
   <build_export_depend>nav_msgs</build_export_depend>
-  <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>rxros</build_export_depend>
   <build_export_depend>sensor_msgs</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
@@ -33,7 +31,6 @@
   <exec_depend>brickpi3_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>nav_msgs</exec_depend>
-  <exec_depend>roscpp</exec_depend>
   <exec_depend>rxros</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>

--- a/brickpi3/src/BrickPi3.cpp
+++ b/brickpi3/src/BrickPi3.cpp
@@ -1,0 +1,760 @@
+/*
+ *  https://www.dexterindustries.com/BrickPi/
+ *  https://github.com/DexterInd/BrickPi3
+ *
+ *  Copyright (c) 2017 Dexter Industries
+ *  Released under the MIT license (http://choosealicense.com/licenses/mit/).
+ *  For more information see https://github.com/DexterInd/BrickPi3/blob/master/LICENSE.md
+ *
+ *  C++ drivers for the BrickPi3
+ */
+
+#include "BrickPi3.h"
+
+BrickPi3::BrickPi3(uint8_t addr){
+  if(spi_file_handle < 0){
+    if(spi_setup()){
+      fatal_error("spi_setup error");
+    }
+  }
+
+  if(addr < 1 || addr > 255){
+    fatal_error("error: SPI address must be in the range of 1 to 255");
+  }
+  Address = addr;
+}
+
+int BrickPi3::spi_write_8(uint8_t msg_type, uint8_t value){
+  spi_array_out[0] = Address;
+  spi_array_out[1] = msg_type;
+  spi_array_out[2] = (value & 0xFF);
+  return spi_transfer_array(3, spi_array_out, spi_array_in);
+}
+
+int BrickPi3::spi_read_16(uint8_t msg_type, uint16_t &value){
+  value = 0;
+  spi_array_out[0] = Address;
+  spi_array_out[1] = msg_type;
+  // assign error to the value returned by spi_transfer_array, and if not 0:
+  if(int error = spi_transfer_array(6, spi_array_out, spi_array_in)){
+    return error;
+  }
+  if(spi_array_in[3] != 0xA5){
+    return ERROR_SPI_RESPONSE;
+  }
+  value = ((spi_array_in[4] << 8) | spi_array_in[5]);
+  return ERROR_NONE;
+}
+
+int BrickPi3::spi_read_32(uint8_t msg_type, uint32_t &value){
+  value = 0;
+  spi_array_out[0] = Address;
+  spi_array_out[1] = msg_type;
+  // assign error to the value returned by spi_transfer_array, and if not 0:
+  if(int error = spi_transfer_array(8, spi_array_out, spi_array_in)){
+    return error;
+  }
+  if(spi_array_in[3] != 0xA5){
+    return ERROR_SPI_RESPONSE;
+  }
+  value = ((spi_array_in[4] << 24) | (spi_array_in[5] << 16) | (spi_array_in[6] << 8) | spi_array_in[7]);
+  return ERROR_NONE;
+}
+
+int BrickPi3::spi_read_string(uint8_t msg_type, char *str, uint8_t chars){
+  if((chars + 4) > LONGEST_SPI_TRANSFER){
+    return -3;
+  }
+  spi_array_out[0] = Address;
+  spi_array_out[1] = msg_type;
+  // assign error to the value returned by spi_transfer_array, and if not 0:
+  if(int error = spi_transfer_array(chars + 4, spi_array_out, spi_array_in)){
+    return error;
+  }
+  if(spi_array_in[3] != 0xA5){
+    return ERROR_SPI_RESPONSE;
+  }
+  for(uint8_t i = 0; i < chars; i++){
+    str[i] = spi_array_in[i + 4];
+  }
+  return ERROR_NONE;
+}
+
+int BrickPi3::detect(bool critical){
+  char ErrorStr[100];
+  char str[21];
+  int error;
+  // assign error to the value returned by get_manufacturer, and if not 0:
+  if(error = get_manufacturer(str)){
+    if(critical){
+      fatal_error("detect error: get_manufacturer failed. Perhaps the BrickPi3 is not connected, or the address is incorrect.");
+    }else{
+      return error;
+    }
+  }
+  if(strstr(str, "Dexter Industries") != str){
+    if(critical){
+      fatal_error("detect error: get_manufacturer string is not 'Dexter Industries'");
+    }else{
+      return ERROR_WRONG_MANUFACTURER;
+    }
+  }
+
+  // assign error to the value returned by get_board, and if not 0:
+  if(error = get_board(str)){
+    if(critical){
+      fatal_error("detect error: get_board failed");
+    }else{
+      return error;
+    }
+  }
+  if(strstr(str, "BrickPi3") != str){
+    if(critical){
+      fatal_error("detect error: get_board string is not 'BrickPi3'");
+    }else{
+      return ERROR_WRONG_DEVICE;
+    }
+  }
+
+  // assign error to the value returned by get_version_firmware, and if not 0:
+  if(error = get_version_firmware(str)){
+    if(critical){
+      fatal_error("detect error: get_version_firmware failed");
+    }else{
+      return error;
+    }
+  }
+  if(strstr(str, FIRMWARE_VERSION_REQUIRED) != str){
+    if(critical){
+      sprintf(ErrorStr, "detect error: BrickPi3 firmware needs to be version %sx but is currently version %s", FIRMWARE_VERSION_REQUIRED, str);
+      fatal_error(ErrorStr);
+    }else{
+      return ERROR_FIRMWARE_MISMATCH;
+    }
+  }
+  return ERROR_NONE;
+}
+
+int BrickPi3::get_manufacturer(char *str){
+  return spi_read_string(BPSPI_MESSAGE_GET_MANUFACTURER, str);
+}
+
+int BrickPi3::get_board(char *str){
+  return spi_read_string(BPSPI_MESSAGE_GET_NAME, str);
+}
+
+int BrickPi3::get_version_hardware(char *str){
+  uint32_t value;
+  // assign error to the value returned by spi_read_32, and if not 0:
+  if(int error = spi_read_32(BPSPI_MESSAGE_GET_HARDWARE_VERSION, value)){
+    return error;
+  }
+  sprintf(str, "%d.%d.%d", (value / 1000000), ((value / 1000) % 1000), (value % 1000));
+}
+
+int BrickPi3::get_version_firmware(char *str){
+  uint32_t value;
+  // assign error to the value returned by spi_read_32, and if not 0:
+  if(int error = spi_read_32(BPSPI_MESSAGE_GET_FIRMWARE_VERSION, value)){
+    return error;
+  }
+  sprintf(str, "%d.%d.%d", (value / 1000000), ((value / 1000) % 1000), (value % 1000));
+  return ERROR_NONE;
+}
+
+int BrickPi3::get_id(char *str){
+  spi_array_out[0] = Address;
+  spi_array_out[1] = BPSPI_MESSAGE_GET_ID;
+  // assign error to the value returned by spi_read_32, and if not 0:
+  if(int error = spi_transfer_array(20, spi_array_out, spi_array_in)){
+    return error;
+  }
+  if(spi_array_in[3] != 0xA5){
+    return ERROR_SPI_RESPONSE;
+  }
+  for(int i = 0; i < 16; i++){
+    sprintf((str + (i * 2)), "%02X", spi_array_in[i + 4]);
+  }
+  return ERROR_NONE;
+}
+
+int  BrickPi3::set_led(uint8_t value){
+  return spi_write_8(BPSPI_MESSAGE_SET_LED, value);
+}
+
+float BrickPi3::get_voltage_3v3(){
+  float voltage;
+  int res = get_voltage_3v3(voltage);
+  if(res)return res;
+  return voltage;
+}
+
+int BrickPi3::get_voltage_3v3(float &voltage){
+  uint16_t value;
+  int res = spi_read_16(BPSPI_MESSAGE_GET_VOLTAGE_3V3, value);
+  voltage = value / 1000.0;
+  return res;
+}
+
+float BrickPi3::get_voltage_5v(){
+  float voltage;
+  int res = get_voltage_5v(voltage);
+  if(res)return res;
+  return voltage;
+}
+
+int BrickPi3::get_voltage_5v(float &voltage){
+  uint16_t value;
+  int res = spi_read_16(BPSPI_MESSAGE_GET_VOLTAGE_5V, value);
+  voltage = value / 1000.0;
+  return res;
+}
+
+float BrickPi3::get_voltage_9v(){
+  float voltage;
+  int res = get_voltage_9v(voltage);
+  if(res)return res;
+  return voltage;
+}
+
+int BrickPi3::get_voltage_9v(float &voltage){
+  uint16_t value;
+  int res = spi_read_16(BPSPI_MESSAGE_GET_VOLTAGE_9V, value);
+  voltage = value / 1000.0;
+  return res;
+}
+
+float BrickPi3::get_voltage_battery(){
+  float voltage;
+  int res = get_voltage_battery(voltage);
+  if(res)return res;
+  return voltage;
+}
+
+int BrickPi3::get_voltage_battery(float &voltage){
+  uint16_t value;
+  int res = spi_read_16(BPSPI_MESSAGE_GET_VOLTAGE_VCC, value);
+  voltage = value / 1000.0;
+  return res;
+}
+
+int BrickPi3::set_sensor_type(uint8_t port, uint8_t type, uint16_t flags, i2c_struct_t *i2c_struct){
+  for(uint8_t p = 0; p < 4; p++){
+    if(port & (1 << p)){
+      SensorType[p] = type;
+    }
+  }
+  spi_array_out[0] = Address;
+  spi_array_out[1] = BPSPI_MESSAGE_SET_SENSOR_TYPE;
+  spi_array_out[2] = port;
+  spi_array_out[3] = type;
+  uint8_t spi_transfer_length = 4;
+
+  if(type == SENSOR_TYPE_CUSTOM){
+    spi_array_out[4] = ((flags >> 8) & 0xFF);
+    spi_array_out[5] = (flags & 0xFF);
+    spi_transfer_length = 6;
+  }else if(type == SENSOR_TYPE_I2C){
+    spi_array_out[4] = flags & 0xFF;
+    spi_array_out[5] = i2c_struct->speed;
+    if(flags & SENSOR_CONFIG_I2C_REPEAT){
+      spi_array_out[6] = ((i2c_struct->delay >> 24) & 0xFF);
+      spi_array_out[7] = ((i2c_struct->delay >> 16) & 0xFF);
+      spi_array_out[8] = ((i2c_struct->delay >> 8) & 0xFF);
+      spi_array_out[9] = (i2c_struct->delay & 0xFF);
+      spi_array_out[10] = i2c_struct->address;
+      if(i2c_struct->length_read > LONGEST_I2C_TRANSFER){
+        i2c_struct->length_read = LONGEST_I2C_TRANSFER;
+      }
+      spi_array_out[11] = i2c_struct->length_read;
+      for(uint8_t p = 0; p < 4; p++){
+        if(port & (1 << p)){
+          I2CInBytes[p] = i2c_struct->length_read;
+        }
+      }
+      if(i2c_struct->length_write > LONGEST_I2C_TRANSFER){
+        i2c_struct->length_write = LONGEST_I2C_TRANSFER;
+      }
+      spi_array_out[12] = i2c_struct->length_write;
+      for(uint8_t i = 0; i < i2c_struct->length_write; i++){
+        spi_array_out[13 + i] = i2c_struct->buffer_write[i];
+      }
+      spi_transfer_length = 13 + i2c_struct->length_write;
+    }else{
+      spi_transfer_length = 6;
+    }
+  }
+
+  return spi_transfer_array(spi_transfer_length, spi_array_out, spi_array_in);
+}
+
+int BrickPi3::transact_i2c(uint8_t port, i2c_struct_t *i2c_struct){
+  uint8_t msg_type;
+  switch(port){
+    case PORT_1:
+      msg_type = BPSPI_MESSAGE_I2C_TRANSACT_1;
+    break;
+    case PORT_2:
+      msg_type = BPSPI_MESSAGE_I2C_TRANSACT_2;
+    break;
+    case PORT_3:
+      msg_type = BPSPI_MESSAGE_I2C_TRANSACT_3;
+    break;
+    case PORT_4:
+      msg_type = BPSPI_MESSAGE_I2C_TRANSACT_4;
+    break;
+    default:
+      fatal_error("transact_i2c error. Must be one sensor port at a time. PORT_1, PORT_2, PORT_3, or PORT_4.");
+  }
+
+  spi_array_out[0] = Address;
+  spi_array_out[1] = msg_type;
+  spi_array_out[2] = i2c_struct->address;
+
+  if(i2c_struct->length_read > LONGEST_I2C_TRANSFER){
+    i2c_struct->length_read = LONGEST_I2C_TRANSFER;
+  }
+  spi_array_out[3] = i2c_struct->length_read;
+  for(uint8_t p = 0; p < 4; p++){
+    if(port & (1 << p)){
+      I2CInBytes[p] = i2c_struct->length_read;
+    }
+  }
+
+  if(i2c_struct->length_write > LONGEST_I2C_TRANSFER){
+    i2c_struct->length_write = LONGEST_I2C_TRANSFER;
+  }
+  spi_array_out[4] = i2c_struct->length_write;
+
+  for(uint8_t i = 0; i < i2c_struct->length_write; i++){
+    spi_array_out[5 + i] = i2c_struct->buffer_write[i];
+  }
+
+  return spi_transfer_array((5 + i2c_struct->length_write), spi_array_out, spi_array_in);
+}
+
+int BrickPi3::get_sensor(uint8_t port, void *value_ptr){
+  uint8_t port_index;
+  uint8_t msg_type;
+  switch(port){
+    case PORT_1:
+      port_index = 0;
+      msg_type = BPSPI_MESSAGE_GET_SENSOR_1;
+    break;
+    case PORT_2:
+      port_index = 1;
+      msg_type = BPSPI_MESSAGE_GET_SENSOR_2;
+    break;
+    case PORT_3:
+      port_index = 2;
+      msg_type = BPSPI_MESSAGE_GET_SENSOR_3;
+    break;
+    case PORT_4:
+      port_index = 3;
+      msg_type = BPSPI_MESSAGE_GET_SENSOR_4;
+    break;
+    default:
+      fatal_error("get_sensor error. Must be one sensor port at a time. PORT_1, PORT_2, PORT_3, or PORT_4.");
+  }
+
+  spi_array_out[0] = Address;
+  spi_array_out[1] = msg_type;
+
+  uint8_t spi_transfer_length;
+
+  // Determine the SPI transaction byte length based on the sensor type
+  switch(SensorType[port_index]){
+    case SENSOR_TYPE_TOUCH:
+    case SENSOR_TYPE_TOUCH_NXT:
+    case SENSOR_TYPE_TOUCH_EV3:
+    case SENSOR_TYPE_NXT_ULTRASONIC:
+    case SENSOR_TYPE_EV3_COLOR_REFLECTED:
+    case SENSOR_TYPE_EV3_COLOR_AMBIENT:
+    case SENSOR_TYPE_EV3_COLOR_COLOR:
+    case SENSOR_TYPE_EV3_ULTRASONIC_LISTEN:
+    case SENSOR_TYPE_EV3_INFRARED_PROXIMITY:
+      spi_transfer_length = 7;
+    break;
+    case SENSOR_TYPE_NXT_LIGHT_ON:
+    case SENSOR_TYPE_NXT_LIGHT_OFF:
+    case SENSOR_TYPE_NXT_COLOR_RED:
+    case SENSOR_TYPE_NXT_COLOR_GREEN:
+    case SENSOR_TYPE_NXT_COLOR_BLUE:
+    case SENSOR_TYPE_NXT_COLOR_OFF:
+    case SENSOR_TYPE_EV3_GYRO_ABS:
+    case SENSOR_TYPE_EV3_GYRO_DPS:
+    case SENSOR_TYPE_EV3_ULTRASONIC_CM:
+    case SENSOR_TYPE_EV3_ULTRASONIC_INCHES:
+      spi_transfer_length = 8;
+    break;
+    case SENSOR_TYPE_CUSTOM:
+    case SENSOR_TYPE_EV3_COLOR_RAW_REFLECTED:
+    case SENSOR_TYPE_EV3_GYRO_ABS_DPS:
+    case SENSOR_TYPE_EV3_INFRARED_REMOTE:
+      spi_transfer_length = 10;
+    break;
+    case SENSOR_TYPE_NXT_COLOR_FULL:
+      spi_transfer_length = 12;
+    break;
+    case SENSOR_TYPE_EV3_COLOR_COLOR_COMPONENTS:
+    case SENSOR_TYPE_EV3_INFRARED_SEEK:
+      spi_transfer_length = 14;
+    break;
+    case SENSOR_TYPE_I2C:
+      spi_transfer_length = 6 + I2CInBytes[port_index];
+    break;
+
+    // Invalid or unsupported sensor type
+    default:
+      return SENSOR_STATE_NOT_CONFIGURED;
+    break;
+  }
+
+  // Get the sensor value(s), and if error
+  // assign error to the value returned by spi_transfer_array, and if not 0:
+  if(int error = spi_transfer_array(spi_transfer_length, spi_array_out, spi_array_in)){
+    return error;
+  }
+  // If the fourth byte received is not 0xA5
+  if(spi_array_in[3] != 0xA5){
+    return ERROR_SPI_RESPONSE;
+  }
+  // If the sensor type is not what it should be
+  if(!(spi_array_in[4] == SensorType[port_index] || (SensorType[port_index] == SENSOR_TYPE_TOUCH && (spi_array_in[4] == SENSOR_TYPE_TOUCH_NXT || spi_array_in[4] == SENSOR_TYPE_TOUCH_EV3)))){
+    return ERROR_SENSOR_TYPE_MISMATCH;
+  }
+  // If the sensor value(s) is not valid (still configuring the sensor, or error communicating with the sensor)
+  if(spi_array_in[5] != SENSOR_STATE_VALID_DATA){
+    return spi_array_in[5];
+  }
+
+  // Get some commonly used values
+  uint8_t  raw_value_8 = spi_array_in[6];
+  uint16_t raw_value_16 = ((spi_array_in[6] << 8) | spi_array_in[7]);
+  uint16_t raw_value_16_2 = ((spi_array_in[8] << 8) | spi_array_in[9]);
+
+  // For each sensor type, copy the value(s) into the corresponding structure value(s)
+  if(SensorType[port_index] == SENSOR_TYPE_TOUCH ||
+     SensorType[port_index] == SENSOR_TYPE_TOUCH_NXT ||
+     SensorType[port_index] == SENSOR_TYPE_TOUCH_EV3){
+    sensor_touch_t *Value = (sensor_touch_t*)value_ptr;
+    Value->pressed = raw_value_8;
+  }else if(SensorType[port_index] == SENSOR_TYPE_NXT_ULTRASONIC){
+    sensor_ultrasonic_t *Value = (sensor_ultrasonic_t*)value_ptr;
+    Value->cm = raw_value_8;
+    Value->inch = raw_value_8 / 2.54;
+  }else if(SensorType[port_index] == SENSOR_TYPE_EV3_COLOR_REFLECTED){
+    sensor_color_t *Value = (sensor_color_t*)value_ptr;
+    Value->reflected_red = raw_value_8;
+  }else if(SensorType[port_index] == SENSOR_TYPE_EV3_COLOR_AMBIENT){
+    sensor_color_t *Value = (sensor_color_t*)value_ptr;
+    Value->ambient = raw_value_8;
+  }else if(SensorType[port_index] == SENSOR_TYPE_EV3_COLOR_COLOR){
+    sensor_color_t *Value = (sensor_color_t*)value_ptr;
+    Value->color = raw_value_8;
+  }else if(SensorType[port_index] == SENSOR_TYPE_EV3_ULTRASONIC_LISTEN){
+    sensor_ultrasonic_t *Value = (sensor_ultrasonic_t*)value_ptr;
+    Value->presence = raw_value_8;
+  }else if(SensorType[port_index] == SENSOR_TYPE_EV3_INFRARED_PROXIMITY){
+    sensor_infrared_t *Value = (sensor_infrared_t*)value_ptr;
+    Value->proximity = raw_value_8;
+  }else if(SensorType[port_index] == SENSOR_TYPE_NXT_LIGHT_ON){
+    sensor_light_t *Value = (sensor_light_t*)value_ptr;
+    Value->reflected = raw_value_16;
+  }else if(SensorType[port_index] == SENSOR_TYPE_NXT_LIGHT_OFF){
+    sensor_light_t *Value = (sensor_light_t*)value_ptr;
+    Value->ambient = raw_value_16;
+  }else if(SensorType[port_index] == SENSOR_TYPE_NXT_COLOR_RED){
+    sensor_color_t *Value = (sensor_color_t*)value_ptr;
+    Value->reflected_red = raw_value_16;
+  }else if(SensorType[port_index] == SENSOR_TYPE_NXT_COLOR_GREEN){
+    sensor_color_t *Value = (sensor_color_t*)value_ptr;
+    Value->reflected_green = raw_value_16;
+  }else if(SensorType[port_index] == SENSOR_TYPE_NXT_COLOR_BLUE){
+    sensor_color_t *Value = (sensor_color_t*)value_ptr;
+    Value->reflected_blue = raw_value_16;
+  }else if(SensorType[port_index] == SENSOR_TYPE_NXT_COLOR_OFF){
+    sensor_color_t *Value = (sensor_color_t*)value_ptr;
+    Value->ambient = raw_value_16;
+  }else if(SensorType[port_index] == SENSOR_TYPE_EV3_GYRO_ABS){
+    sensor_gyro_t *Value = (sensor_gyro_t*)value_ptr;
+    Value->abs = raw_value_16;
+  }else if(SensorType[port_index] == SENSOR_TYPE_EV3_GYRO_DPS){
+    sensor_gyro_t *Value = (sensor_gyro_t*)value_ptr;
+    Value->dps = raw_value_16;
+  }else if(SensorType[port_index] == SENSOR_TYPE_EV3_ULTRASONIC_CM){
+    sensor_ultrasonic_t *Value = (sensor_ultrasonic_t*)value_ptr;
+    Value->cm = raw_value_16 / 10.0;
+    Value->inch = raw_value_16 / 25.4;
+  }else if(SensorType[port_index] == SENSOR_TYPE_EV3_ULTRASONIC_INCHES){
+    sensor_ultrasonic_t *Value = (sensor_ultrasonic_t*)value_ptr;
+    Value->cm = raw_value_16 * 0.254;
+    Value->inch = raw_value_16 / 10.0;
+  }else if(SensorType[port_index] == SENSOR_TYPE_CUSTOM){
+    sensor_custom_t *Value = (sensor_custom_t*)value_ptr;
+    Value->adc1 = (((spi_array_in[8] & 0x0F) << 8) | spi_array_in[9]);
+    Value->adc6 = (((spi_array_in[8] >> 4) & 0x0F) | (spi_array_in[7] << 4));
+    Value->pin5 = (spi_array_in[6] & 0x01);
+    Value->pin6 = ((spi_array_in[6] >> 1) & 0x01);
+  }else if(SensorType[port_index] == SENSOR_TYPE_EV3_COLOR_RAW_REFLECTED){
+    sensor_color_t *Value = (sensor_color_t*)value_ptr;
+    Value->reflected_red = raw_value_16;
+    //Value-> = raw_value_16_2; not sure what this value is
+  }else if(SensorType[port_index] == SENSOR_TYPE_EV3_GYRO_ABS_DPS){
+    sensor_gyro_t *Value = (sensor_gyro_t*)value_ptr;
+    Value->abs = raw_value_16;
+    Value->dps = raw_value_16_2;
+  }else if(SensorType[port_index] == SENSOR_TYPE_EV3_INFRARED_REMOTE){
+    sensor_infrared_t *Value = (sensor_infrared_t*)value_ptr;
+    for(uint8_t v = 0; v < 4; v++){
+      switch(spi_array_in[6 + v]){
+        case 1:
+          Value->remote[v] = REMOTE_BIT_RED_UP;
+        break;
+        case 2:
+          Value->remote[v] = REMOTE_BIT_RED_DOWN;
+        break;
+        case 3:
+          Value->remote[v] = REMOTE_BIT_BLUE_UP;
+        break;
+        case 4:
+          Value->remote[v] = REMOTE_BIT_BLUE_DOWN;
+        break;
+        case 5:
+          Value->remote[v] = REMOTE_BIT_RED_UP | REMOTE_BIT_BLUE_UP;
+        break;
+        case 6:
+          Value->remote[v] = REMOTE_BIT_RED_UP | REMOTE_BIT_BLUE_DOWN;
+        break;
+        case 7:
+          Value->remote[v] = REMOTE_BIT_RED_DOWN | REMOTE_BIT_BLUE_UP;
+        break;
+        case 8:
+          Value->remote[v] = REMOTE_BIT_RED_DOWN | REMOTE_BIT_BLUE_DOWN;
+        break;
+        case 9:
+          Value->remote[v] = REMOTE_BIT_BROADCAST;
+        break;
+        case 10:
+          Value->remote[v] = REMOTE_BIT_RED_UP | REMOTE_BIT_RED_DOWN;
+        break;
+        case 11:
+          Value->remote[v] = REMOTE_BIT_BLUE_UP | REMOTE_BIT_BLUE_DOWN;
+        break;
+        default:
+          Value->remote[v] = 0;
+        break;
+      }
+    }
+  }else if(SensorType[port_index] == SENSOR_TYPE_NXT_COLOR_FULL){
+    sensor_color_t *Value = (sensor_color_t*)value_ptr;
+    Value->color           = spi_array_in[6];
+    Value->reflected_red   = ((spi_array_in[ 7] << 2) | ((spi_array_in[11] >> 6) & 0x03));
+    Value->reflected_green = ((spi_array_in[ 8] << 2) | ((spi_array_in[11] >> 4) & 0x03));
+    Value->reflected_blue  = ((spi_array_in[ 9] << 2) | ((spi_array_in[11] >> 2) & 0x03));
+    Value->ambient         = ((spi_array_in[10] << 2) | ( spi_array_in[11]       & 0x03));
+  }else if(SensorType[port_index] == SENSOR_TYPE_EV3_COLOR_COLOR_COMPONENTS){
+    sensor_color_t *Value = (sensor_color_t*)value_ptr;
+    Value->reflected_red   = ((spi_array_in[ 6] << 8) | spi_array_in[ 7]);
+    Value->reflected_green = ((spi_array_in[ 8] << 8) | spi_array_in[ 9]);
+    Value->reflected_blue  = ((spi_array_in[10] << 8) | spi_array_in[11]);
+    //Value-> = ((spi_array_in[12] << 8) | spi_array_in[13]); not sure what this value is
+  }else if(SensorType[port_index] == SENSOR_TYPE_EV3_INFRARED_SEEK){
+    sensor_infrared_t *Value = (sensor_infrared_t*)value_ptr;
+    for(uint8_t v = 0; v < 4; v++){
+      Value->heading [v] = spi_array_in[6 + (v * 2)];
+      Value->distance[v] = spi_array_in[7 + (v * 2)];
+    }
+  }else if(SensorType[port_index] == SENSOR_TYPE_I2C){
+    i2c_struct_t *Value = (i2c_struct_t*)value_ptr;
+    for(uint8_t b = 0; b < I2CInBytes[port_index]; b++){
+      Value->buffer_read[b] = spi_array_in[6 + b];
+    }
+  }
+  return SENSOR_STATE_VALID_DATA;
+}
+
+int BrickPi3::set_motor_power(uint8_t port, int8_t power){
+  spi_array_out[0] = Address;
+  spi_array_out[1] = BPSPI_MESSAGE_SET_MOTOR_POWER;
+  spi_array_out[2] = port;
+  spi_array_out[3] = power;
+  return spi_transfer_array(4, spi_array_out, spi_array_in);
+}
+
+int BrickPi3::set_motor_position(uint8_t port, int32_t position){
+  spi_array_out[0] = Address;
+  spi_array_out[1] = BPSPI_MESSAGE_SET_MOTOR_POSITION;
+  spi_array_out[2] = port;
+  spi_array_out[3] = ((position >> 24) & 0xFF);
+  spi_array_out[4] = ((position >> 16) & 0xFF);
+  spi_array_out[5] = ((position >> 8) & 0xFF);
+  spi_array_out[6] = (position & 0xFF);
+  return spi_transfer_array(7, spi_array_out, spi_array_in);
+}
+
+int BrickPi3::set_motor_position_relative(uint8_t port, int32_t position){
+  for(uint8_t p = 1; p <= PORT_D; p <<= 1){
+    if(port & p){
+      int32_t encoder = 0;
+      // assign error to the error value returned by get_motor_encoder, and if not 0:
+      if(int error = get_motor_encoder(p, encoder)){
+        return error;
+      }
+      // assign error to the error value returned by get_motor_encoder, and if not 0:
+      if(int error = set_motor_position(p, (encoder + position))){
+        return error;
+      }
+    }
+  }
+  return ERROR_NONE;
+}
+
+int BrickPi3::set_motor_dps(uint8_t port, int16_t dps){
+  spi_array_out[0] = Address;
+  spi_array_out[1] = BPSPI_MESSAGE_SET_MOTOR_DPS;
+  spi_array_out[2] = port;
+  spi_array_out[3] = ((dps >> 8) & 0xFF);
+  spi_array_out[4] = (dps & 0xFF);
+  return spi_transfer_array(5, spi_array_out, spi_array_in);
+}
+
+int BrickPi3::set_motor_limits(uint8_t port, uint8_t power, uint16_t dps){
+  spi_array_out[0] = Address;
+  spi_array_out[1] = BPSPI_MESSAGE_SET_MOTOR_LIMITS;
+  spi_array_out[2] = port;
+  spi_array_out[3] = power;
+  spi_array_out[4] = ((dps >> 8) & 0xFF);
+  spi_array_out[5] = (dps & 0xFF);
+  return spi_transfer_array(6, spi_array_out, spi_array_in);
+}
+
+int BrickPi3::get_motor_status(uint8_t port, uint8_t &state, int8_t &power, int32_t &position, int16_t &dps){
+  uint8_t msg_type;
+  switch(port){
+    case PORT_A:
+      msg_type = BPSPI_MESSAGE_GET_MOTOR_A_STATUS;
+    break;
+    case PORT_B:
+      msg_type = BPSPI_MESSAGE_GET_MOTOR_B_STATUS;
+    break;
+    case PORT_C:
+      msg_type = BPSPI_MESSAGE_GET_MOTOR_C_STATUS;
+    break;
+    case PORT_D:
+      msg_type = BPSPI_MESSAGE_GET_MOTOR_D_STATUS;
+    break;
+    default:
+      fatal_error("get_motor_status error. Must be one motor port at a time. PORT_A, PORT_B, PORT_C, or PORT_D.");
+  }
+  spi_array_out[0] = Address;
+  spi_array_out[1] = msg_type;
+  // assign error to the value returned by spi_transfer_array, and if not 0:
+  if(int error = spi_transfer_array(12, spi_array_out, spi_array_in)){
+    return error;
+  }
+
+  if(spi_array_in[3] != 0xA5){
+    return ERROR_SPI_RESPONSE;
+  }
+
+  state    = spi_array_in[4];
+  power    = spi_array_in[5];
+  position = ((spi_array_in[6] << 24) | (spi_array_in[7] << 16) | (spi_array_in[8] << 8) | spi_array_in[9]);
+  dps      = ((spi_array_in[10] << 8) | spi_array_in[11]);
+
+  return ERROR_NONE;
+}
+
+int BrickPi3::offset_motor_encoder(uint8_t port, int32_t position){
+  spi_array_out[0] = Address;
+  spi_array_out[1] = BPSPI_MESSAGE_OFFSET_MOTOR_ENCODER;
+  spi_array_out[2] = port;
+  spi_array_out[3] = ((position >> 24) & 0xFF);
+  spi_array_out[4] = ((position >> 16) & 0xFF);
+  spi_array_out[5] = ((position >> 8) & 0xFF);
+  spi_array_out[6] = (position & 0xFF);
+  return spi_transfer_array(7, spi_array_out, spi_array_in);
+}
+
+int BrickPi3::reset_motor_encoder(uint8_t port){
+  int32_t value;
+  int error = 1;
+  for(uint8_t p = 1; p <= PORT_D; p <<= 1){
+    if(port & p){
+      error = reset_motor_encoder(p, value);
+      if(error){
+        return error;
+      }
+    }
+  }
+  if(error){
+    fatal_error("reset_motor_encoder error. Must be one or more motor ports. PORT_A, PORT_B, PORT_C, and/or PORT_D.");
+  }
+  return ERROR_NONE;
+}
+
+int BrickPi3::reset_motor_encoder(uint8_t port, int32_t &value){
+  value = 0;
+  // assign error to the error value returned by get_motor_encoder, and if not 0:
+  if(int error = get_motor_encoder(port, value)){
+    return error;
+  }
+  return offset_motor_encoder(port, value);
+}
+
+int BrickPi3::set_motor_encoder(uint8_t port, int32_t value){
+  int32_t enc_value = 0;
+  // assign error to the error value returned by get_motor_encoder, and if not 0:
+  if(int error = get_motor_encoder(port, enc_value)){
+    return error;
+  }
+  return offset_motor_encoder(port, (enc_value - value));
+}
+
+int32_t BrickPi3::get_motor_encoder(uint8_t port){
+  int32_t value;
+  get_motor_encoder(port, value);
+  return value;
+}
+
+int BrickPi3::get_motor_encoder(uint8_t port, int32_t &value){
+  uint8_t msg_type;
+  switch(port){
+    case PORT_A:
+      msg_type = BPSPI_MESSAGE_GET_MOTOR_A_ENCODER;
+    break;
+    case PORT_B:
+      msg_type = BPSPI_MESSAGE_GET_MOTOR_B_ENCODER;
+    break;
+    case PORT_C:
+      msg_type = BPSPI_MESSAGE_GET_MOTOR_C_ENCODER;
+    break;
+    case PORT_D:
+      msg_type = BPSPI_MESSAGE_GET_MOTOR_D_ENCODER;
+    break;
+    default:
+      fatal_error("get_motor_encoder error. Must be one motor port at a time. PORT_A, PORT_B, PORT_C, or PORT_D.");
+  }
+  uint32_t Value;
+  int res = spi_read_32(msg_type, Value);
+  value = Value;
+  return res;
+}
+
+int BrickPi3::reset_all(){
+  int res1 = set_sensor_type(PORT_1 + PORT_2 + PORT_3 + PORT_4, SENSOR_TYPE_NONE);
+  int res2 = set_motor_power(PORT_A + PORT_B + PORT_C + PORT_D, MOTOR_FLOAT);
+  int res3 = set_motor_limits(PORT_A + PORT_B + PORT_C + PORT_D, 0, 0);
+  int res4 = set_led(-1);
+  if(res1){
+    return res1;
+  }else if(res2){
+    return res2;
+  }else if(res3){
+    return res3;
+  }else if(res4){
+    return res4;
+  }
+  return ERROR_NONE;
+}

--- a/brickpi3/src/BrickPi3.h
+++ b/brickpi3/src/BrickPi3.h
@@ -1,0 +1,409 @@
+/*
+ *  https://www.dexterindustries.com/BrickPi/
+ *  https://github.com/DexterInd/BrickPi3
+ *
+ *  Copyright (c) 2017 Dexter Industries
+ *  Released under the MIT license (http://choosealicense.com/licenses/mit/).
+ *  For more information see https://github.com/DexterInd/BrickPi3/blob/master/LICENSE.md
+ *
+ *  C++ drivers for the BrickPi3
+ */
+
+#ifndef BRICKPI3_ROS_BRICKPI3_H
+#define BRICKPI3_ROS_BRICKPI3_H
+
+#define FIRMWARE_VERSION_REQUIRED "1.4." // Firmware version needs to start with this
+
+#define LONGEST_SPI_TRANSFER 29 // longest possible message for configuring for an I2C sensor
+#define LONGEST_I2C_TRANSFER 16 // longest possible I2C read/write
+
+#define SPI_TARGET_SPEED 500000 // SPI target speed of 500kbps
+
+#define SPIDEV_FILE_NAME "/dev/spidev0.1" // File name of SPI
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <linux/spi/spidev.h>
+#include <stdio.h>            // for printf
+#include <string.h>           // for strstr
+
+//#include <linux/types.h>
+//#include <getopt.h>
+//#include <unistd.h>
+
+// Error values
+#define ERROR_NONE                  0
+#define ERROR_SPI_FILE             -1
+#define ERROR_SPI_RESPONSE         -2
+#define ERROR_WRONG_MANUFACTURER   -3
+#define ERROR_WRONG_DEVICE         -4
+#define ERROR_FIRMWARE_MISMATCH    -5
+#define ERROR_SENSOR_TYPE_MISMATCH -6
+
+static int spi_file_handle = -1;                    // SPI file handle
+static struct spi_ioc_transfer spi_xfer_struct;     // SPI transfer struct
+static uint8_t spi_array_out[LONGEST_SPI_TRANSFER]; // SPI out array
+static uint8_t spi_array_in[LONGEST_SPI_TRANSFER];  // SPI in array
+
+// Set up SPI. Open the file, and define the configuration.
+static int spi_setup(){
+  spi_file_handle = open(SPIDEV_FILE_NAME, O_RDWR);
+
+  if (spi_file_handle < 0){
+    return ERROR_SPI_FILE;
+  }
+
+  spi_xfer_struct.cs_change = 0;               // Keep CS activated
+  spi_xfer_struct.delay_usecs = 0;             // delay in us
+  spi_xfer_struct.speed_hz = SPI_TARGET_SPEED; // speed
+  spi_xfer_struct.bits_per_word = 8;           // bites per word 8
+
+  return ERROR_NONE;
+}
+
+// Transfer length number of bytes. Write from outArray, read to inArray.
+static int spi_transfer_array(uint8_t length, uint8_t *outArray, uint8_t *inArray){
+  spi_xfer_struct.len = length;
+  spi_xfer_struct.tx_buf = (unsigned long)outArray;
+  spi_xfer_struct.rx_buf = (unsigned long)inArray;
+
+  if (ioctl(spi_file_handle, SPI_IOC_MESSAGE(1), &spi_xfer_struct) < 0) {
+    return ERROR_SPI_FILE;
+  }
+
+  return ERROR_NONE;
+}
+
+// Function to call if an error occured that can not be resolved, such as failure to set up SPI
+static void fatal_error(char *error){
+  printf("%s", error);
+  printf("\n");
+  exit(-1);
+}
+
+// Function to call if an error occured that can not be resolved, such as failure to set up SPI
+static void fatal_error(const char *error){
+  printf("%s", error);
+  printf("\n");
+  exit(-1);
+}
+
+// SPI message type
+enum BPSPI_MESSAGE_TYPE{
+  BPSPI_MESSAGE_NONE,
+
+  BPSPI_MESSAGE_GET_MANUFACTURER,      // 1
+  BPSPI_MESSAGE_GET_NAME,
+  BPSPI_MESSAGE_GET_HARDWARE_VERSION,
+  BPSPI_MESSAGE_GET_FIRMWARE_VERSION,
+  BPSPI_MESSAGE_GET_ID,
+  BPSPI_MESSAGE_SET_LED,
+  BPSPI_MESSAGE_GET_VOLTAGE_3V3,
+  BPSPI_MESSAGE_GET_VOLTAGE_5V,
+  BPSPI_MESSAGE_GET_VOLTAGE_9V,
+  BPSPI_MESSAGE_GET_VOLTAGE_VCC,
+  BPSPI_MESSAGE_SET_ADDRESS,           // 11
+
+  BPSPI_MESSAGE_SET_SENSOR_TYPE,       // 12
+
+  BPSPI_MESSAGE_GET_SENSOR_1,          // 13
+  BPSPI_MESSAGE_GET_SENSOR_2,
+  BPSPI_MESSAGE_GET_SENSOR_3,
+  BPSPI_MESSAGE_GET_SENSOR_4,
+
+  BPSPI_MESSAGE_I2C_TRANSACT_1,        // 17
+  BPSPI_MESSAGE_I2C_TRANSACT_2,
+  BPSPI_MESSAGE_I2C_TRANSACT_3,
+  BPSPI_MESSAGE_I2C_TRANSACT_4,
+
+  BPSPI_MESSAGE_SET_MOTOR_POWER,
+
+  BPSPI_MESSAGE_SET_MOTOR_POSITION,
+
+  BPSPI_MESSAGE_SET_MOTOR_POSITION_KP,
+
+  BPSPI_MESSAGE_SET_MOTOR_POSITION_KD, // 24
+
+  BPSPI_MESSAGE_SET_MOTOR_DPS,         // 25
+
+  BPSPI_MESSAGE_SET_MOTOR_DPS_KP,
+
+  BPSPI_MESSAGE_SET_MOTOR_DPS_KD,
+
+  BPSPI_MESSAGE_SET_MOTOR_LIMITS,
+
+  BPSPI_MESSAGE_OFFSET_MOTOR_ENCODER,  // 29
+
+  BPSPI_MESSAGE_GET_MOTOR_A_ENCODER,   // 30
+  BPSPI_MESSAGE_GET_MOTOR_B_ENCODER,
+  BPSPI_MESSAGE_GET_MOTOR_C_ENCODER,
+  BPSPI_MESSAGE_GET_MOTOR_D_ENCODER,
+
+  BPSPI_MESSAGE_GET_MOTOR_A_STATUS,    // 34
+  BPSPI_MESSAGE_GET_MOTOR_B_STATUS,
+  BPSPI_MESSAGE_GET_MOTOR_C_STATUS,
+  BPSPI_MESSAGE_GET_MOTOR_D_STATUS
+};
+
+// Sensor type
+enum SENSOR_TYPE{
+  SENSOR_TYPE_NONE = 1, // Not configured for any sensor type
+  SENSOR_TYPE_I2C,
+  SENSOR_TYPE_CUSTOM,   // Choose 9v pullup, pin 5 and 6 configuration, and what to read back (ADC 1 and/or ADC 6 (always reports digital 5 and 6)).
+
+  SENSOR_TYPE_TOUCH,    // Touch sensor. When this mode is selected, automatically configure for NXT/EV3 as necessary.
+  SENSOR_TYPE_TOUCH_NXT,
+  SENSOR_TYPE_TOUCH_EV3,
+
+  SENSOR_TYPE_NXT_LIGHT_ON,
+  SENSOR_TYPE_NXT_LIGHT_OFF,
+
+  SENSOR_TYPE_NXT_COLOR_RED,
+  SENSOR_TYPE_NXT_COLOR_GREEN,
+  SENSOR_TYPE_NXT_COLOR_BLUE,
+  SENSOR_TYPE_NXT_COLOR_FULL,
+  SENSOR_TYPE_NXT_COLOR_OFF,
+
+  SENSOR_TYPE_NXT_ULTRASONIC,
+
+  SENSOR_TYPE_EV3_GYRO_ABS,
+  SENSOR_TYPE_EV3_GYRO_DPS,
+  SENSOR_TYPE_EV3_GYRO_ABS_DPS,
+
+  SENSOR_TYPE_EV3_COLOR_REFLECTED,
+  SENSOR_TYPE_EV3_COLOR_AMBIENT,
+  SENSOR_TYPE_EV3_COLOR_COLOR,
+  SENSOR_TYPE_EV3_COLOR_RAW_REFLECTED,
+  SENSOR_TYPE_EV3_COLOR_COLOR_COMPONENTS,
+
+  SENSOR_TYPE_EV3_ULTRASONIC_CM,
+  SENSOR_TYPE_EV3_ULTRASONIC_INCHES,
+  SENSOR_TYPE_EV3_ULTRASONIC_LISTEN,
+
+  SENSOR_TYPE_EV3_INFRARED_PROXIMITY,
+  SENSOR_TYPE_EV3_INFRARED_SEEK,
+  SENSOR_TYPE_EV3_INFRARED_REMOTE
+};
+
+// Sensor states/error values
+enum SENSOR_STATE{
+  SENSOR_STATE_VALID_DATA,
+  SENSOR_STATE_NOT_CONFIGURED,
+  SENSOR_STATE_CONFIGURING,
+  SENSOR_STATE_NO_DATA,
+  SENSOR_STATE_I2C_ERROR        // Such as no ACK, SCL stretched too long, etc.
+};
+
+// Flags for configuring custom and I2C sensors
+enum SENSOR_CONFIG_FLAGS{
+  SENSOR_CONFIG_I2C_MID_CLOCK = 0x0001, // I2C. Send a clock pulse between reading and writing. Required by the NXT US sensor.
+  SENSOR_CONFIG_PIN_1_PULL    = 0x0002, // I2C or custom. Enable 9v pullup on pin 1
+  SENSOR_CONFIG_I2C_REPEAT    = 0x0004, // I2C. Keep performing the same transaction e.g. keep polling a sensor
+  SENSOR_CONFIG_PIN_5_DIR     = 0x0010, // Custom. Set pin 5 output
+  SENSOR_CONFIG_PIN_5_STATE   = 0x0020, // Custom. Set pin 5 high
+  SENSOR_CONFIG_PIN_6_DIR     = 0x0100, // Custom. Set pin 6 output
+  SENSOR_CONFIG_PIN_6_STATE   = 0x0200, // Custom. Set pin 6 high
+  SENSOR_CONFIG_REPORT_1_ADC  = 0x1000, // Custom. Read pin 1 ADC
+  SENSOR_CONFIG_REPORT_6_ADC  = 0x4000  // Custom. Read pin 6 ADC
+};
+
+// Sensor ports
+#define PORT_1 0x01
+#define PORT_2 0x02
+#define PORT_3 0x04
+#define PORT_4 0x08
+
+// Motor ports
+#define PORT_A 0x01
+#define PORT_B 0x02
+#define PORT_C 0x04
+#define PORT_D 0x08
+
+// Motor Float. Value to pass to set_motor_power to make a motor float.
+#define MOTOR_FLOAT -128
+
+// EV3 infrared remote button bit masks
+#define REMOTE_BIT_RED_UP    0x01
+#define REMOTE_BIT_RED_DOWN  0x02
+#define REMOTE_BIT_BLUE_UP   0x04
+#define REMOTE_BIT_BLUE_DOWN 0x08
+#define REMOTE_BIT_BROADCAST 0x10
+
+// structure for I2C
+struct i2c_struct_t{
+  uint8_t speed;
+  uint8_t delay;
+  uint8_t address;
+  uint8_t length_write;
+  uint8_t buffer_write[LONGEST_I2C_TRANSFER];
+  uint8_t length_read;
+  uint8_t buffer_read[LONGEST_I2C_TRANSFER];
+};
+
+// structure for custom sensors
+struct sensor_custom_t{
+  uint16_t adc1;
+  uint16_t adc6;
+  bool     pin5;
+  bool     pin6;
+};
+
+// structure for touch sensors
+struct sensor_touch_t{
+  bool     pressed;
+};
+
+// structure for light sensor
+struct sensor_light_t{
+  int16_t  ambient;
+  int16_t  reflected;
+};
+
+// structure for color sensors
+struct sensor_color_t{
+  int8_t   color;
+  int16_t  reflected_red;
+  int16_t  reflected_green;
+  int16_t  reflected_blue;
+  int16_t  ambient;
+};
+
+// structure for ultrasonic sensors
+struct sensor_ultrasonic_t{
+  float    cm;
+  float    inch;
+  bool     presence;
+};
+
+// structure for gyro sensor
+struct sensor_gyro_t{
+  int16_t  abs;
+  int16_t  dps;
+};
+
+// structure for infrared sensor
+struct sensor_infrared_t{
+  uint8_t  proximity;
+  int8_t   distance[4];
+  int8_t   heading[4];
+  uint8_t  remote[4];
+};
+
+// Set a BrickPi3's address to allow stacking
+static int BrickPi3_set_address(int addr, const char *id){
+  if(addr < 1 || addr > 255){
+    fatal_error("BrickPi3_set_address error: invalid address. Must be in the range of 1 to 255");
+    return -1;
+  }
+
+  spi_array_out[0] = 0;                         // use address 0 so all BrickPi3s will listen, regardless of current address
+  spi_array_out[1] = BPSPI_MESSAGE_SET_ADDRESS;
+  spi_array_out[2] = addr;
+  for(uint8_t i = 0; i < 16; i++){
+    if(strlen(id) == 32){
+      char id_str[2];
+      id_str[0] = *(id + (i * 2));
+      id_str[1] = *(id + (i * 2) + 1);
+      spi_array_out[3 + i] = strtol(id_str, NULL, 16);
+    }else if(strlen(id) == 0){
+      spi_array_out[3 + i] = 0;
+    }else{
+      fatal_error("BrickPi3_set_address error: wrong serial number id length. Must be a 32-digit hex string.");
+    }
+  }
+  if(spi_transfer_array(19, spi_array_out, spi_array_in)){
+    return -1;
+  }
+}
+
+class BrickPi3{
+  public:
+  // Default to address 1, but the BrickPi3 address could have been changed.
+    BrickPi3(uint8_t addr = 1);
+
+  // Confirm that the BrickPi3 is connected and up-to-date
+    int     detect(bool critical = true);
+
+  // Get the manufacturer (should be "Dexter Industries")
+    int     get_manufacturer(char *str);
+  // Get the board name (should be "BrickPi3")
+    int     get_board(char *str);
+  // Get the hardware version number
+    int     get_version_hardware(char *str);
+  // Get the firmware version number
+    int     get_version_firmware(char *str);
+  // Get the serial number ID that is unique to each BrickPi3
+    int     get_id(char *str);
+  // Control the LED
+    int     set_led(uint8_t value);
+
+  // Get the voltages of the four power rails
+    // Get the voltage and return as floating point voltage
+    float   get_voltage_3v3    ();
+    float   get_voltage_5v     ();
+    float   get_voltage_9v     ();
+    float   get_voltage_battery();
+    // Pass the pass-by-reference float variable where the voltage will be stored. Returns the error code.
+    int     get_voltage_3v3    (float &voltage);
+    int     get_voltage_5v     (float &voltage);
+    int     get_voltage_9v     (float &voltage);
+    int     get_voltage_battery(float &voltage);
+
+  // Configure a sensor
+    // Pass the port(s), sensor type, and optionally extra sensor configurations (flags and I2C information).
+    int     set_sensor_type(uint8_t port, uint8_t type, uint16_t flags = 0, i2c_struct_t *i2c_struct = NULL);
+  // Configure and trigger an I2C transaction
+    int     transact_i2c(uint8_t port, i2c_struct_t *i2c_struct);
+  // Get sensor value(s)
+    int     get_sensor(uint8_t port, void *value_ptr);
+
+  // Set the motor PWM power
+    int     set_motor_power(uint8_t port, int8_t power);
+  // Set the motor target position to run to
+    // Set the absolute position to run to (go to the specified position)
+    int     set_motor_position(uint8_t port, int32_t position);
+    // Set the relative position to run to (go to the current position plus the specified position)
+    int     set_motor_position_relative(uint8_t port, int32_t position);
+  // Set the motor speed in degrees per second.
+    int     set_motor_dps(uint8_t port, int16_t dps);
+  // Set the motor limits.
+  // Use the power limit to limit the motor speed/torque in speed or position control modes.
+  // Use dps limit to limit the motor speed in position control mode.
+    int     set_motor_limits(uint8_t port, uint8_t power, uint16_t dps);
+  // Get the motor status. State, PWM power, encoder position, and speed (in degrees per second)
+    int     get_motor_status(uint8_t port, uint8_t &state, int8_t &power, int32_t &position, int16_t &dps);
+  // Offset the encoder position. By setting the offset to the current position, it effectively resets the encoder value.
+    int     offset_motor_encoder(uint8_t port, int32_t position);
+  // Reset the encoder.
+    // Pass the port and pass-by-reference variable where the old encoder value will be stored. Returns the error code.
+    int     reset_motor_encoder(uint8_t port, int32_t &value);
+    // Pass the port. Returns the error code.
+    int     reset_motor_encoder(uint8_t port);
+  // Set the encoder position.
+    // Pass the port and the new encoder position. Returns the error code.
+    int     set_motor_encoder(uint8_t port, int32_t value);
+  // Get the encoder position
+    // Pass the port and pass-by-reference variable where the encoder value will be stored. Returns the error code.
+    int     get_motor_encoder(uint8_t port, int32_t &value);
+    // Pass the port. Returns the encoder value.
+    int32_t get_motor_encoder(uint8_t port);
+
+  // Reset the sensors (unconfigure), motors (float with no limits), and LED (return control to the firmware).
+    int     reset_all();
+
+  private:
+    // BrickPi3 SPI address
+    uint8_t Address;
+
+    uint8_t SensorType[4];
+    uint8_t I2CInBytes[4];
+
+    int spi_write_8(uint8_t msg_type, uint8_t value);
+    int spi_read_16(uint8_t msg_type, uint16_t &value);
+    int spi_read_32(uint8_t msg_type, uint32_t &value);
+    int spi_read_string(uint8_t msg_type, char *str, uint8_t chars = 20);
+};
+
+#endif

--- a/brickpi3/src/BrickPi3BaseController.cpp
+++ b/brickpi3/src/BrickPi3BaseController.cpp
@@ -1,0 +1,163 @@
+/*
+Copyright (c) 2019, ROSIN-project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <mutex>
+#include <stdio.h>
+#include <string>
+#include <Scheduler.h>
+#include <ros/ros.h>
+#include <ros/console.h>
+#include <geometry_msgs/Twist.h>
+#include <sensor_msgs/JointState.h>
+#include <brickpi3_msgs/JointCommand.h>
+#include "Node.h"
+
+
+class BrickPi3BaseController {
+private:
+    std::mutex mutex;
+    ros::Publisher jointCommandPublisher;
+    ros::Subscriber cmdVelSubscriber;
+    ros::Subscriber jointStatesSubscriber;
+    unsigned int seqNo;
+    std::string lWheelJoint;
+    std::string rWheelJoint;
+    double wheelRadius;
+    double wheelBasis;
+    double lastDesiLinVel;
+    double lastDesiAngVel;
+    double desiLWheelVel;
+    double desiRWheelVel;
+    double factorLWheel;
+    double factorRWheel;
+
+    void cmdVelSubscriberCB(const geometry_msgs::Twist& jointStates);
+    void jointStatesSubscriberCB(const sensor_msgs::JointState& jointStates);
+
+public:
+    BrickPi3BaseController(int argc, char** argv);
+    virtual ~BrickPi3BaseController() {};
+    void run() {ros::spin();}
+};
+
+BrickPi3BaseController::BrickPi3BaseController(int argc, char** argv) :
+    jointCommandPublisher(Node::getHandle().advertise<brickpi3_msgs::JointCommand>("/joint_command", 10)),
+    cmdVelSubscriber(Node::getHandle().subscribe("/cmd_vel", 10, &BrickPi3BaseController::cmdVelSubscriberCB, this)),
+    jointStatesSubscriber(Node::getHandle().subscribe("/joint_states", 10, &BrickPi3BaseController::jointStatesSubscriberCB, this)),
+    seqNo(0),
+    lastDesiLinVel(0.0),
+    lastDesiAngVel(0.0),
+    desiLWheelVel(0.0),
+    desiRWheelVel(0.0),
+    factorLWheel(0.0),
+    factorRWheel(0.0)
+{
+    Node::getHandle().param<std::string>("/brickpi3_base_controller/l_wheel_joint", lWheelJoint, "l_wheel_joint");
+    Node::getHandle().param<std::string>("/brickpi3_base_controller/r_wheel_joint", rWheelJoint, "r_wheel_joint");
+    Node::getHandle().param("/brickpi3_base_controller/wheel_radius", wheelRadius, 0.028); // m
+    Node::getHandle().param("/brickpi3_base_controller/wheel_basis", wheelBasis, 0.0625); // m
+
+    printf("l_wheel_joint: %s\n", lWheelJoint.c_str());
+    printf("r_wheel_joint: %s m/s\n", rWheelJoint.c_str());
+    printf("wheel_radius: %f rad/s\n", wheelRadius);
+    printf("wheel_basis: %f rad/s\n", wheelBasis);
+}
+
+void BrickPi3BaseController::cmdVelSubscriberCB(const geometry_msgs::Twist& twist)
+{
+    std::lock_guard<std::mutex> guard(mutex);
+
+    double desiLinVel = twist.linear.x;
+    double desiAngVel = twist.angular.z;
+    if ((desiLinVel != lastDesiLinVel) || (desiAngVel != lastDesiAngVel)) {
+        desiLWheelVel = desiLinVel - desiAngVel * wheelBasis; // m/s
+        desiRWheelVel = desiLinVel + desiAngVel * wheelBasis; // m/s
+//        (self.factor_l_joint, self.factor_r_joint) = get_default_factor(self.vel_l_joint_desi, self.vel_r_joint_desi)
+        lastDesiLinVel = desiLinVel;
+        lastDesiAngVel = desiAngVel;
+    }
+}
+
+void BrickPi3BaseController::jointStatesSubscriberCB(const sensor_msgs::JointState& jointStates)
+{
+    std::lock_guard<std::mutex> guard(mutex);
+
+    double currLWheelVel = 0.0; // rad/s
+    double currRWheelVel = 0.0; // rad/s
+    for (int i = 0; i < jointStates.name.size(); i++) {
+        if (lWheelJoint.compare(jointStates.name[i]) == 0) {
+            currLWheelVel = jointStates.velocity[i];
+        }
+        else if (rWheelJoint.compare(jointStates.name[i]) == 0) {
+            currRWheelVel = jointStates.velocity[i];
+        }
+    }
+    currLWheelVel *= wheelRadius; // m/s
+    currRWheelVel *= wheelRadius; // m/s
+
+    if (currLWheelVel != 0.0) { // left wheel is turning
+        double factor = desiLWheelVel / currLWheelVel; // perfect is 1.0
+        factorLWheel += (factor > 1.0) ? 0.01 : -0.01;
+    }
+    else if (desiLWheelVel != 0.0) { // wheel is not turning should it?
+        factorLWheel += 0.05;
+    }
+
+    if (currRWheelVel != 0.0) { // right wheel is turning
+        double factor = desiRWheelVel / currRWheelVel; // perfect is 1.0
+        factorRWheel += (factor > 1.0) ? 0.01 : -0.01;
+    }
+    else if (desiRWheelVel != 0.0) { // wheel is not turning should it?
+        factorRWheel += 0.05;
+    }
+
+    // Wheel commands
+    brickpi3_msgs::JointCommand lJointCommand;
+    lJointCommand.name = lWheelJoint;
+    lJointCommand.effort = desiLWheelVel * factorLWheel;
+    jointCommandPublisher.publish(lJointCommand);
+
+    brickpi3_msgs::JointCommand rJointCommand;
+    rJointCommand.name = rWheelJoint;
+    rJointCommand.effort = desiRWheelVel * factorRWheel;
+    jointCommandPublisher.publish(rJointCommand);
+
+//     rospy.loginfo("current %f m/s, %f m/s", vel_l_joint_curr, vel_r_joint_curr)
+//     rospy.loginfo("desired %f m/s, %f m/s", self.vel_l_joint_desi, self.vel_r_joint_desi)
+//     rospy.loginfo("factor %f, %f", self.factor_l_joint, self.factor_r_joint)
+//     rospy.loginfo("cmd %f, %f", l_cmd.effort, r_cmd.effort)
+}
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "brickpi3_base_controller"); // Name of this node.
+    BrickPi3BaseController BrickPi3BaseController(argc, argv);
+    BrickPi3BaseController.run();
+}

--- a/brickpi3/src/BrickPi3BaseController.cpp
+++ b/brickpi3/src/BrickPi3BaseController.cpp
@@ -31,7 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <mutex>
 #include <stdio.h>
 #include <string>
-#include <Scheduler.h>
+#include "ext/Scheduler.h"
 #include <ros/ros.h>
 #include <ros/console.h>
 #include <geometry_msgs/Twist.h>

--- a/brickpi3/src/BrickPi3BaseController_rx.cpp
+++ b/brickpi3/src/BrickPi3BaseController_rx.cpp
@@ -1,0 +1,108 @@
+/*
+Copyright (c) 2019, ROSIN-project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <algorithm>
+#include <rxros.h>
+#include <geometry_msgs/Twist.h>
+#include <sensor_msgs/JointState.h>
+#include <brickpi3_msgs/JointCommand.h>
+using namespace rxcpp::operators;
+using namespace rxros::operators;
+
+enum WheelId{ LEFT_WHEEL = 0, RIGHT_WHEEL = 1};
+
+
+int main(int argc, char** argv)
+{
+    rxros::init(argc, argv, "brickpi3_base_controller"); // Name of this node.
+
+    const auto l_wheel_joint = rxros::parameter::get("/brickpi3/l_wheel_joint", "l_wheel_joint");
+    const auto r_wheel_joint = rxros::parameter::get("/brickpi3/r_wheel_joint", "r_wheel_joint");
+    const auto wheel_radius = rxros::parameter::get("/brickpi3/wheel_radius", 0.028); // m
+    const auto wheel_basis = rxros::parameter::get("/brickpi3/wheel_basis", 0.0625); // m
+
+    rxros::logging().info() << "brickpi3_base_controller:";
+    rxros::logging().info() << "l_wheel_joint: " << l_wheel_joint;
+    rxros::logging().info() << "r_wheel_joint: " << r_wheel_joint;
+    rxros::logging().info() << "wheel_radius: " << wheel_radius;
+    rxros::logging().info() << "wheel_basis: " << wheel_basis;
+
+    auto adjust_factor = [] (const auto& curr_factor, const auto& curr_vel, const auto& desi_vel) {
+        if (curr_vel != 0.0) // wheel is turning
+            return curr_factor + ((desi_vel / curr_vel) > 1.0) ? 0.01 : -0.01;
+        else if (desi_vel != 0.0) // wheel is not turning should it?
+            return curr_factor + 0.05;
+        else
+            return curr_factor;};
+
+    auto desired_wheel_vel = [=](const auto& wheel, const auto& cmd_vel) {
+        if (wheel == LEFT_WHEEL)
+            return cmd_vel.linear.x - cmd_vel.angular.z * wheel_basis; // m/s
+        else if (wheel == RIGHT_WHEEL)
+            return cmd_vel.linear.x + cmd_vel.angular.z * wheel_basis;}; // m/s
+
+    auto curr_wheel_vel = [=](const auto& wheel, const auto& joint_states) {
+        return joint_states.velocity[wheel] * wheel_radius;};
+
+    auto update_effort = [=](const auto& prevTuple, const auto& tuple) {  // tuple: joint_states, cmd_vel
+        const auto last_factor_lWheel = std::get<2>(prevTuple);
+        const auto last_factor_rWheel = std::get<3>(prevTuple);
+        const auto joint_states = std::get<0>(tuple);
+        const auto cmd_vel = std::get<1>(tuple);
+        const auto curr_factor_lWheel = adjust_factor(last_factor_lWheel, curr_wheel_vel(LEFT_WHEEL, joint_states), desired_wheel_vel(LEFT_WHEEL, cmd_vel));
+        const auto curr_factor_rWheel = adjust_factor(last_factor_rWheel, curr_wheel_vel(RIGHT_WHEEL, joint_states), desired_wheel_vel(RIGHT_WHEEL, cmd_vel));
+        return std::make_tuple(
+            desired_wheel_vel(LEFT_WHEEL, cmd_vel) * curr_factor_lWheel, // effort for left wheel
+            desired_wheel_vel(RIGHT_WHEEL, cmd_vel) * curr_factor_rWheel, // effort for right wheel
+            curr_factor_lWheel,
+            curr_factor_rWheel);};
+
+    auto effort_2_joint_cmd = [=] (const auto& wheel) {
+        return [=](const auto& tuple) {
+            brickpi3_msgs::JointCommand jointCommand;
+            jointCommand.name = (wheel == LEFT_WHEEL) ? l_wheel_joint : r_wheel_joint;
+            jointCommand.effort = (wheel == LEFT_WHEEL) ? std::get<0>(tuple) : std::get<1>(tuple);
+            return jointCommand;};};
+
+    auto joint_states_observable = rxros::observable::from_topic<sensor_msgs::JointState>("/joint_states");
+    auto cmd_vel_observable = rxros::observable::from_topic<geometry_msgs::Twist>("/cmd_vel");
+    auto effort_observable = joint_states_observable.with_latest_from([](const auto& js, const auto& cv) {return std::make_tuple(js, cv);}, cmd_vel_observable)
+        | scan(std::make_tuple(0.0, 0.0, 0.0, 0.0), update_effort); // tuple: effort left wheel, effort right wheel, factor left wheel, factor right wheel.
+
+    effort_observable
+    | map(effort_2_joint_cmd(LEFT_WHEEL))
+    | publish_to_topic<brickpi3_msgs::JointCommand>("/joint_command");
+
+    effort_observable
+    | map(effort_2_joint_cmd(RIGHT_WHEEL))
+    | publish_to_topic<brickpi3_msgs::JointCommand>("/joint_command");
+
+    rxros::spin();
+}

--- a/brickpi3/src/BrickPi3BaseController_rx.cpp
+++ b/brickpi3/src/BrickPi3BaseController_rx.cpp
@@ -29,7 +29,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <algorithm>
-#include <rxros.h>
+#include <rxros/rxros.h>
 #include <geometry_msgs/Twist.h>
 #include <sensor_msgs/JointState.h>
 #include <brickpi3_msgs/JointCommand.h>

--- a/brickpi3/src/BrickPi3Color.cpp
+++ b/brickpi3/src/BrickPi3Color.cpp
@@ -1,0 +1,74 @@
+/*
+Copyright (c) 2019, ROSIN-project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <string>
+#include <iostream>
+#include <brickpi3_msgs/Color.h>
+#include "Node.h"
+#include "BrickPi3Color.h"
+
+
+BrickPi3Color::BrickPi3Color(const std::string& aName, const std::string& aFrameId, const std::string& aPort, const double aFrequency):
+    colorPublisher(Node::getHandle().advertise<brickpi3_msgs::Color>("/" + aName, 10))
+{
+    name = aName;
+    frameId = aFrameId;
+    port = port2id(aPort);
+    freq = aFrequency;
+    seqNo = 0;
+
+    brickPi3.set_sensor_type(port, SENSOR_TYPE_NXT_COLOR_FULL);
+}
+
+
+void BrickPi3Color::schedulerCB()
+{
+    std::lock_guard<std::mutex> guard(mutex);
+
+    sensor_color_t sensorColor;
+    int rc = brickPi3.get_sensor(port, &sensorColor);
+    if (rc == 0) {
+        ROS_DEBUG("Color sensor: detected %d red %4d green %4d blue %4d ambient %4d", sensorColor.color, sensorColor.reflected_red, sensorColor.reflected_green, sensorColor.reflected_blue, sensorColor.ambient);
+
+        brickpi3_msgs::Color color;
+        color.header.frame_id = frameId;
+        color.header.stamp = ros::Time::now();
+        color.header.seq = seqNo++;
+        color.r = static_cast<double>(sensorColor.reflected_red);
+        color.g = static_cast<double>(sensorColor.reflected_green);
+        color.b = static_cast<double>(sensorColor.reflected_blue);
+        color.intensity = static_cast<double>(sensorColor.ambient);
+
+        colorPublisher.publish(color);
+    }
+    else {
+        ROS_ERROR("BrickPi3 failed to read Color sensor %s, rc %d", name.c_str(), rc);
+    }
+}

--- a/brickpi3/src/BrickPi3Color.h
+++ b/brickpi3/src/BrickPi3Color.h
@@ -1,0 +1,63 @@
+/*
+Copyright (c) 2019, ROSIN-project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef BRICKPI3_BRICKPI3COLOR_H
+#define BRICKPI3_BRICKPI3COLOR_H
+
+#include <string>
+#include <ros/ros.h>
+#include <ros/console.h>
+#include "BrickPi3Device.h"
+
+
+class BrickPi3Color: public BrickPi3Device
+{
+private:
+    ros::Publisher colorPublisher;
+    std::string name;
+    std::string frameId;
+    uint8_t port;
+    double freq;
+    unsigned int seqNo;
+
+public:
+    BrickPi3Color(const std::string& name, const std::string& frameId, const std::string& port, const double frequency);
+    virtual ~BrickPi3Color() {}
+
+    const std::string& getName() const {return name;}
+    const std::string& getFrameId() const {return frameId;}
+    const uint8_t getPort() const {return port;}
+    const double getFreq() const {return freq;}
+
+    void schedulerCB();
+};
+
+
+#endif //BRICKPI3_BRICKPI3COLOR_H

--- a/brickpi3/src/BrickPi3Device.h
+++ b/brickpi3/src/BrickPi3Device.h
@@ -1,0 +1,67 @@
+/*
+Copyright (c) 2019, ROSIN-project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef BRICKPI3_BRICKPI3DEVICE_H
+#define BRICKPI3_BRICKPI3DEVICE_H
+
+#include <climits>
+#include <string>
+#include <mutex>
+#include "BrickPi3.h"
+
+
+static uint8_t port2id(const std::string& port)
+{
+    int id = ((port == "PORT_A") ? PORT_A :
+             ((port == "PORT_B") ? PORT_B :
+             ((port == "PORT_C") ? PORT_C :
+             ((port == "PORT_D") ? PORT_D :
+             ((port == "PORT_1") ? PORT_1 :
+             ((port == "PORT_2") ? PORT_2 :
+             ((port == "PORT_3") ? PORT_3 :
+             ((port == "PORT_4") ? PORT_4 : INT_MAX))))))));
+    return static_cast<uint8_t>(id);
+}
+
+
+class BrickPi3Device
+{
+protected:
+    BrickPi3 brickPi3;
+    std::mutex mutex;
+
+public:
+    BrickPi3Device() {brickPi3.detect();}
+    virtual ~BrickPi3Device() {brickPi3.reset_all();}
+
+    virtual void schedulerCB() = 0;
+};
+
+#endif //BRICKPI3_BRICKPI3DEVICE_H

--- a/brickpi3/src/BrickPi3JointStatesPublisher.cpp
+++ b/brickpi3/src/BrickPi3JointStatesPublisher.cpp
@@ -1,0 +1,98 @@
+/*
+Copyright (c) 2019, ROSIN-project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <algorithm>
+#include <ros/ros.h>
+#include <ros/console.h>
+#include <sensor_msgs/JointState.h>
+#include "Node.h"
+
+
+class BrickPi3JointStatesPublisher
+{
+private:
+    ros::Subscriber jointStateSubscriber;
+    ros::Publisher jointStatesPublisher;
+    sensor_msgs::JointState jointStates;
+    unsigned int seqNo;
+
+    void jointStateSubscriberCB(const sensor_msgs::JointState& jointState);
+
+public:
+    BrickPi3JointStatesPublisher(int argc, char** argv);
+    virtual ~BrickPi3JointStatesPublisher() {}
+    void run() {ros::spin();}
+};
+
+
+BrickPi3JointStatesPublisher::BrickPi3JointStatesPublisher(int argc, char** argv):
+    jointStatesPublisher(Node::getHandle().advertise<sensor_msgs::JointState>("/joint_states", 10)),
+    jointStateSubscriber(Node::getHandle().subscribe("/joint_state", 10, &BrickPi3JointStatesPublisher::jointStateSubscriberCB, this)),
+    seqNo(0)
+{
+}
+
+void BrickPi3JointStatesPublisher::jointStateSubscriberCB(const sensor_msgs::JointState& jointState)
+{
+    if (std::find(jointStates.name.begin(), jointStates.name.end(), jointState.name[0]) != jointStates.name.end()) { // name already exists in the makeJointStates
+        jointStates.name.clear();
+        jointStates.effort.clear();
+        jointStates.position.clear();
+        jointStates.velocity.clear();
+    }
+//    for (int i = 0; i < makeJointStates.name.size(); i++) {
+//        if (makeJointStates.name[i] == jointState.name[0]) {
+//            makeJointStates.name.erase(makeJointStates.name.begin() + i);
+//            makeJointStates.effort.erase(makeJointStates.effort.begin() + i);
+//            makeJointStates.position.erase(makeJointStates.position.begin() + i);
+//            makeJointStates.velocity.erase(makeJointStates.velocity.begin() + i);
+//        }
+//    }
+    jointStates.name.push_back(jointState.name[0]);
+    jointStates.effort.push_back(jointState.effort[0]);
+    jointStates.position.push_back(jointState.position[0]); // rad
+    jointStates.velocity.push_back(jointState.velocity[0]); // rad/s
+
+    if (jointStates.name.size() == 2) // todo: Find way to determine the number of motors.
+    {
+        //makeJointStates.header.frame_id = name;
+        jointStates.header.stamp = ros::Time::now();
+        jointStates.header.seq = seqNo++;
+
+        jointStatesPublisher.publish(jointStates);
+    }
+}
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "brickpi3_joint_states_publisher"); // Name of this node.
+    BrickPi3JointStatesPublisher jointStatesPublisher(argc, argv);
+    jointStatesPublisher.run();
+}

--- a/brickpi3/src/BrickPi3JointStatesPublisher_rx.cpp
+++ b/brickpi3/src/BrickPi3JointStatesPublisher_rx.cpp
@@ -1,0 +1,72 @@
+/*
+Copyright (c) 2019, ROSIN-project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <iostream>
+#include <algorithm>
+#include <rxros.h>
+#include <sensor_msgs/JointState.h>
+using namespace rxcpp::operators;
+using namespace rxros::operators;
+
+auto tuple_2_joint_states = [](const auto& ljs, const auto& rjs) { // tuple: left joint state, right joint state
+    static std::atomic<unsigned int> seqNo(0);
+    sensor_msgs::JointState jointState;
+    //jointState.header.frame_id = name;
+    jointState.header.stamp = ros::Time::now();
+    jointState.header.seq = seqNo++;
+    jointState.name.push_back(ljs.name[0]);
+    jointState.effort.push_back(ljs.effort[0]);
+    jointState.position.push_back(ljs.position[0]); // rad
+    jointState.velocity.push_back(ljs.velocity[0]); // rad/s
+    jointState.name.push_back(rjs.name[0]);
+    jointState.effort.push_back(rjs.effort[0]);
+    jointState.position.push_back(rjs.position[0]); // rad
+    jointState.velocity.push_back(rjs.velocity[0]); // rad/s
+    return jointState;};
+
+int main(int argc, char** argv)
+{
+    rxros::init(argc, argv, "brickpi3_joint_states_publisher"); // Name of this node.
+
+    const auto l_wheel_joint = rxros::parameter::get("/brickpi3/l_wheel_joint", "l_wheel_joint");
+    const auto r_wheel_joint = rxros::parameter::get("/brickpi3/r_wheel_joint", "r_wheel_joint");
+
+    rxros::logging().info() << "brickpi3_joint_states_publisher:";
+    rxros::logging().info() << "l_wheel_joint: " << l_wheel_joint;
+    rxros::logging().info() << "r_wheel_joint: " << r_wheel_joint ;
+
+    const auto joint_state_observable = rxros::observable::from_topic<sensor_msgs::JointState>("/joint_state");
+    const auto left_wheel_observable = joint_state_observable.filter([=](auto& jointState){return (jointState.name[0] == l_wheel_joint);});
+    const auto right_wheel_observable = joint_state_observable.filter([=](auto& jointState){return (jointState.name[0] == r_wheel_joint);});
+    left_wheel_observable.zip(tuple_2_joint_states, right_wheel_observable)
+    | publish_to_topic<sensor_msgs::JointState>("/joint_states");
+
+    rxros::spin();
+}

--- a/brickpi3/src/BrickPi3JointStatesPublisher_rx.cpp
+++ b/brickpi3/src/BrickPi3JointStatesPublisher_rx.cpp
@@ -30,7 +30,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <iostream>
 #include <algorithm>
-#include <rxros.h>
+#include <rxros/rxros.h>
 #include <sensor_msgs/JointState.h>
 using namespace rxcpp::operators;
 using namespace rxros::operators;

--- a/brickpi3/src/BrickPi3Motor.cpp
+++ b/brickpi3/src/BrickPi3Motor.cpp
@@ -1,0 +1,118 @@
+/*
+Copyright (c) 2019, ROSIN-project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <string>
+#include <iostream>
+#include <math.h>
+#include <ros/ros.h>
+#include <sensor_msgs/JointState.h>
+#include <brickpi3_msgs/JointCommand.h>
+#include "Node.h"
+#include "BrickPi3Device.h"
+#include "BrickPi3Motor.h"
+using namespace std;
+
+#define POWER_MAX 1.0
+
+
+BrickPi3Motor::BrickPi3Motor(const string& aName, const string& aPort, const double aFrequency):
+    jointStatePublisher(Node::getHandle().advertise<sensor_msgs::JointState>("/joint_state", 10)),
+    jointCommandSubscriber(Node::getHandle().subscribe("/joint_command", 10, &BrickPi3Motor::jointCommandCB, this)),
+    lastTime(0,0),
+    lastPosition(0)
+{
+    name = aName;
+    port = port2id(aPort);
+    freq = aFrequency;
+    seqNo = 0;
+
+    brickPi3.reset_motor_encoder(port);
+}
+
+BrickPi3Motor::~BrickPi3Motor()
+{
+    brickPi3.reset_motor_encoder(port);
+}
+
+void BrickPi3Motor::jointCommandCB(const brickpi3_msgs::JointCommand& jointCommand)
+{
+    lock_guard<std::mutex> guard(mutex);
+
+    if (name == jointCommand.name) {
+        //Store the commanded power value, limited to the range +/- POWER_MAX
+
+        effort = jointCommand.effort;
+        if (effort > POWER_MAX) {
+            effort = POWER_MAX;
+        } else if (effort < -POWER_MAX) {
+            effort = -POWER_MAX;
+        }
+    }
+}
+
+void BrickPi3Motor::schedulerCB()
+{
+    lock_guard<std::mutex> guard(mutex);
+
+    uint8_t motorState = 0;// Variable for reading motor motorState
+    int8_t motorPower = 0;// Variable for reading motor powers
+    int32_t motorPosition = 0;  // Variable for reading motor encoder positions
+    int16_t motorDPS = 0; // Variable for reading motor speeds (Degrees Per Second)
+
+    int rc = brickPi3.get_motor_status(PORT_A, motorState, motorPower, motorPosition, motorDPS);
+    if (rc == 0) {
+        ROS_DEBUG("State A: %d Power A: %4d  Encoder A: %6d  DPS A: %6d", motorState, motorPower, motorPosition, motorDPS);
+
+        ros::Time currTime = ros::Time::now();
+        double currPosition = static_cast<double>(motorPosition) * M_PI / 180.0 / 3.0;
+        double currVelocity = 0.0;
+        if (!lastTime.isZero()) {
+            currVelocity = (currPosition - lastPosition)/(currTime - lastTime).toSec();
+        }
+        lastPosition = currPosition;
+        lastTime = currTime;
+
+        sensor_msgs::JointState jointState;
+        //jointState.header.frame_id = name;
+        jointState.header.stamp = ros::Time::now();
+        jointState.header.seq = seqNo++;
+        jointState.name.push_back(name);
+        jointState.effort.push_back(effort);
+        jointState.position.push_back(currPosition); // rad
+        jointState.velocity.push_back(currVelocity); // rad/s
+
+        jointStatePublisher.publish(jointState);
+
+        brickPi3.set_motor_power(port, static_cast<int8_t>(effort * 100.0));
+    }
+    else {
+        ROS_ERROR("BrickPi3 failed to read Motor status %s, rc %d", name.c_str(), rc);
+    }
+}

--- a/brickpi3/src/BrickPi3Motor.h
+++ b/brickpi3/src/BrickPi3Motor.h
@@ -1,0 +1,68 @@
+/*
+Copyright (c) 2019, ROSIN-project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef BRICKPI3_BRICKPI3MOTOR_H
+#define BRICKPI3_BRICKPI3MOTOR_H
+
+#include <string>
+#include <ros/ros.h>
+#include <ros/console.h>
+#include <brickpi3_msgs/JointCommand.h>
+#include "BrickPi3Device.h"
+
+
+class BrickPi3Motor: public BrickPi3Device
+{
+private:
+    ros::Publisher jointStatePublisher;
+    ros::Subscriber jointCommandSubscriber;
+    std::string name; // The name of the wheel. Defined in yaml file.
+    uint8_t port; // The BrickPi3 port number. Defined in yaml file.
+    double freq; // Frequency the schedulerCB will be called with. Defined in yaml file.
+    double effort; // The desired effort the motor should use.
+    unsigned int seqNo;
+    ros::Time lastTime;
+    double lastPosition;
+
+    void jointCommandCB(const brickpi3_msgs::JointCommand& jointCommand);
+
+public:
+    BrickPi3Motor(const std::string& name, const std::string& port, const double frequency);
+    virtual ~BrickPi3Motor();
+
+    const std::string getName() const {return name;}
+    uint8_t getPort() const {return port;}
+    double getFreq() const {return freq;}
+    double getEffort() const {return effort;}
+
+    void schedulerCB();
+};
+
+#endif //BRICKPI3_BRICKPI3MOTOR_H

--- a/brickpi3/src/BrickPi3Observable_rx.h
+++ b/brickpi3/src/BrickPi3Observable_rx.h
@@ -1,0 +1,204 @@
+/*
+Copyright (c) 2019, ROSIN-project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef BRICKPI3_BRICKPI3OBSERVABLE_RX_H
+#define BRICKPI3_BRICKPI3OBSERVABLE_RX_H
+
+#include <string>
+#include <rxros.h>
+#include "BrickPi3Device.h"
+
+struct actuator_motor_t
+{
+    uint8_t motorState;// Variable for reading motor motorState
+    int8_t motorPower;// Variable for reading motor powers
+    int32_t motorPosition;  // Variable for reading motor encoder positions
+    int16_t motorDPS; // Variable for reading motor speeds (Degrees Per Second)
+};
+
+
+namespace brickpi3
+{
+    class observable
+    {
+    private:
+        observable() = default;
+
+    public:
+        ~observable() = default;
+
+        static auto touch_sensor(const std::string& name, const std::string& port, double frequency)
+        {
+            auto observable = rxcpp::observable<>::create<sensor_touch_t>(
+                [=](rxcpp::subscriber<sensor_touch_t> subscriber) {
+                    const uint8_t id = port2id(port);
+                    bool errReported = false;
+                    BrickPi3 brickPi3;
+                    brickPi3.detect();
+                    brickPi3.set_sensor_type(id, SENSOR_TYPE_TOUCH_NXT);
+
+                    ros::Rate rate(frequency);
+                    while (rxros::ok()) {
+                        sensor_touch_t touch;
+                        int rc = brickPi3.get_sensor(id, &touch);
+                        if (rc == 0) {
+                            rxros::logging().debug() << "Touch sensor: pressed " << touch.pressed;
+                            subscriber.on_next(touch);
+                        } else {
+                            errReported = true;
+                            brickPi3.reset_all();
+                            subscriber.on_error(rxros::exception::system_error(errno, "BrickPi3 failed to read Touch sensor '" +  name + "' rc: " + std::to_string(rc)));
+                            break;
+                        }
+                        rate.sleep();
+                    }
+                    if (!errReported) {
+                        brickPi3.reset_all();
+                        subscriber.on_completed();
+                    }});
+            return observable.subscribe_on(rxcpp::synchronize_new_thread());
+        }
+
+
+        static auto color_sensor(const std::string& name, const std::string& port, double frequency)
+        {
+            auto observable = rxcpp::observable<>::create<sensor_color_t>(
+                [=](rxcpp::subscriber<sensor_color_t> subscriber) {
+                    const uint8_t id = port2id(port);
+                    bool errReported = false;
+                    BrickPi3 brickPi3;
+                    brickPi3.detect();
+                    brickPi3.set_sensor_type(id, SENSOR_TYPE_NXT_COLOR_FULL);
+
+                    ros::Rate rate(frequency);
+                    while (rxros::ok()) {
+                        sensor_color_t color;
+                        int rc = brickPi3.get_sensor(id, &color);
+                        if (rc == 0) {
+                            rxros::logging().debug() << "Color sensor: " << color.color << ", red: " << color.reflected_red << ", green: " << color.reflected_green << ", blue: " << color.reflected_blue << ", ambient: " << color.ambient;
+                            subscriber.on_next(color);
+                        } else {
+                            errReported = true;
+                            brickPi3.reset_all();
+                            subscriber.on_error(rxros::exception::system_error(errno, "BrickPi3 failed to read Color sensor '" +  name + "' rc: " + std::to_string(rc)));
+                            break;
+                        }
+                        rate.sleep();
+                    }
+                    if (!errReported) {
+                        brickPi3.reset_all();
+                        subscriber.on_completed();
+                    }});
+            return observable.subscribe_on(rxcpp::synchronize_new_thread());
+        }
+
+        static auto ultrasonic_sensor(const std::string& name, const std::string& port, double frequency)
+        {
+            auto observable = rxcpp::observable<>::create<sensor_ultrasonic_t>(
+                [=](rxcpp::subscriber<sensor_ultrasonic_t> subscriber) {
+                    const uint8_t id = port2id(port);
+                    bool errReported = false;
+                    BrickPi3 brickPi3;
+                    brickPi3.detect();
+                    brickPi3.set_sensor_type(id, SENSOR_TYPE_NXT_ULTRASONIC);
+
+                    ros::Rate rate(frequency);
+                    while (rxros::ok()) {
+                        sensor_ultrasonic_t ultrasonic;
+                        int rc = brickPi3.get_sensor(id, &ultrasonic);
+                        if (rc == 0) {
+                            rxros::logging().debug() << "Ultrasonic sensor: cm: " << ultrasonic.cm << ", inches: " << ultrasonic.inch;
+                            subscriber.on_next(ultrasonic);
+                        } else {
+                            errReported = true;
+                            brickPi3.reset_all();
+                            subscriber.on_error(rxros::exception::system_error(errno, "BrickPi3 failed to read Ultrasonic sensor '" +  name + "' rc: " + std::to_string(rc)));
+                            break;
+                        }
+                        rate.sleep();
+                    }
+                    if (!errReported) {
+                        brickPi3.reset_all();
+                        subscriber.on_completed();
+                    }});
+            return observable.subscribe_on(rxcpp::synchronize_new_thread());
+        }
+
+        static auto motor(const std::string &name, const std::string &port, double frequency)
+        {
+            auto observable = rxcpp::observable<>::create<actuator_motor_t>(
+                [=](rxcpp::subscriber<actuator_motor_t> subscriber) {
+                    const uint8_t id = port2id(port);
+                    bool errReported = false;
+                    BrickPi3 brickPi3;
+                    brickPi3.detect();
+                    brickPi3.reset_motor_encoder(id);
+
+                    ros::Rate rate(frequency);
+                    while (rxros::ok()) {
+                        actuator_motor_t motor{};
+                        int rc = brickPi3.get_motor_status(id, motor.motorState, motor.motorPower, motor.motorPosition, motor.motorDPS);
+                        if (rc == 0) {
+                            rxros::logging().debug() << "Motor name '" << name << "', State: " << motor.motorState << ", Power: " << motor.motorPower << ", Position: " << motor.motorPosition << ", DPS: " << motor.motorDPS;
+                            subscriber.on_next(motor);
+                        } else {
+                            errReported = true;
+                            brickPi3.reset_all();
+                            subscriber.on_error(rxros::exception::system_error(errno, "BrickPi3 failed to read Motor '" +  name + "' rc: " + std::to_string(rc)));
+                            break;
+                        }
+                        rate.sleep();
+                    }
+                    if (!errReported) {
+                        brickPi3.reset_all();
+                        subscriber.on_completed();
+                    }});
+            return observable.subscribe_on(rxcpp::synchronize_new_thread());
+        }
+    };// end class observable
+} // end namespace brickpi3
+
+
+namespace brickpi3
+{
+    namespace operators
+    {
+        auto set_motor_power(const std::string& port) {
+            return [=](auto&& source) {
+                const uint8_t id = port2id(port);
+                BrickPi3 brickPi3;
+                source.subscribe_on(rxcpp::synchronize_new_thread()).subscribe(
+                    [&](const auto& jointCommand) {brickPi3.set_motor_power(id, static_cast<int8_t>(jointCommand.effort * 100.0));});
+                return source;};}
+    } // end namespace operators
+} // end namespace brickpi3
+
+
+#endif //BRICKPI3_BRICKPI3OBSERVABLE_RX_H

--- a/brickpi3/src/BrickPi3Observable_rx.h
+++ b/brickpi3/src/BrickPi3Observable_rx.h
@@ -32,7 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define BRICKPI3_BRICKPI3OBSERVABLE_RX_H
 
 #include <string>
-#include <rxros.h>
+#include <rxros/rxros.h>
 #include "BrickPi3Device.h"
 
 struct actuator_motor_t

--- a/brickpi3/src/BrickPi3OdomPublisher.cpp
+++ b/brickpi3/src/BrickPi3OdomPublisher.cpp
@@ -1,0 +1,170 @@
+/*
+Copyright (c) 2019, ROSIN-project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <mutex>
+#include <stdio.h>
+#include <string>
+#include <Scheduler.h>
+#include <ros/ros.h>
+#include <ros/console.h>
+#include <sensor_msgs/JointState.h>
+#include <geometry_msgs/Twist.h>
+#include <geometry_msgs/PoseWithCovariance.h>
+#include <geometry_msgs/Pose.h>
+#include <nav_msgs/Odometry.h>
+#include <tf/transform_broadcaster.h>
+#include "Node.h"
+
+
+class BrickPi3OdomPublisher
+{
+private:
+    ros::Subscriber jointStatesSubscriber;
+    ros::Publisher odomPublisher;
+    tf::TransformBroadcaster transformBroadcaster;
+    unsigned int seqNo;
+    std::string lWheelJoint;
+    std::string rWheelJoint;
+    double wheelRadius;
+    double wheelBasis;
+    double lastLWheelPosition;
+    double lastRWheelPosition;
+    double x, y, th;
+    ros::Time lastTime;
+    bool isInitialized;
+
+    void jointStatesSubscriberCB(const sensor_msgs::JointState& jointStates);
+
+public:
+    BrickPi3OdomPublisher(int argc, char** argv);
+    virtual ~BrickPi3OdomPublisher() {};
+    void run() {ros::spin();}
+};
+
+BrickPi3OdomPublisher::BrickPi3OdomPublisher(int argc, char** argv) :
+    odomPublisher(Node::getHandle().advertise<nav_msgs::Odometry>("/odom", 10)),
+    jointStatesSubscriber(Node::getHandle().subscribe("/joint_states", 10, &BrickPi3OdomPublisher::jointStatesSubscriberCB, this)),
+    transformBroadcaster(),
+    seqNo(0),
+    lastLWheelPosition(0.0),
+    lastRWheelPosition(0.0),
+    x(0.0),
+    y(0.0),
+    th(0.0),
+    lastTime(ros::Time::now()),
+    isInitialized(false)
+{
+    Node::getHandle().param<std::string>("/brickpi3_odom_publisher/l_wheel_joint", lWheelJoint, "l_wheel_joint");
+    Node::getHandle().param<std::string>("/brickpi3_odom_publisher/r_wheel_joint", rWheelJoint, "r_wheel_joint");
+    Node::getHandle().param("/brickpi3_odom_publisher/wheel_radius", wheelRadius, 0.028); // m
+    Node::getHandle().param("/brickpi3_odom_publisher/wheel_basis", wheelBasis, 0.0625); // m
+
+    ROS_DEBUG("l_wheel_joint: %s\n", lWheelJoint.c_str());
+    ROS_DEBUG("r_wheel_joint: %s m/s\n", rWheelJoint.c_str());
+    ROS_DEBUG("wheel_radius: %f rad/s\n", wheelRadius);
+    ROS_DEBUG("wheel_basis: %f rad/s\n", wheelBasis);
+}
+
+void BrickPi3OdomPublisher::jointStatesSubscriberCB(const sensor_msgs::JointState& jointStates)
+{
+    ros::Time currTime = ros::Time::now();
+
+    // find current position of left and right wheel
+    double currLWheelPosition = 0.0;
+    double currRWheelPosition = 0.0;
+    for (int i = 0; i < jointStates.name.size(); i++) {
+        if (lWheelJoint == jointStates.name[i]) {
+            currLWheelPosition = jointStates.position[i];
+        }
+        else if (rWheelJoint == jointStates.name[i]) {
+            currRWheelPosition = jointStates.position[i];
+        }
+    }
+
+    if (isInitialized)
+    {
+        double deltaRWheelPosition = currRWheelPosition - lastRWheelPosition;
+        double deltaLWheelPosition = currLWheelPosition - lastLWheelPosition;
+        double velocityX = (deltaRWheelPosition + deltaLWheelPosition) * wheelRadius / 2.0;
+        double velocityY = 0.0;
+        double velocityTheta = (deltaRWheelPosition - deltaLWheelPosition) * wheelRadius / (2.0 * wheelBasis);
+
+        double dt = (currTime - lastTime).toSec();
+        double dx = (velocityX * cos(th) - velocityY * sin(th)) * dt;
+        double dy = (velocityX * sin(th) + velocityY * cos(th)) * dt;
+        double dth = velocityTheta * dt;
+
+        x += dx;
+        y += dy;
+        th += dth;
+
+        nav_msgs::Odometry odom;
+        odom.header.stamp = currTime;
+        odom.header.seq = seqNo++;
+        odom.header.frame_id = "odom";
+        odom.child_frame_id = "base_footprint";
+
+        //set the position
+        odom.pose.pose.position.x = x;
+        odom.pose.pose.position.y = y;
+        odom.pose.pose.position.z = 0.0;
+        odom.pose.pose.orientation = tf::createQuaternionMsgFromYaw(th);
+        odom.pose.covariance = {0.00001, 0.0,     0.0,     0.0,     0.0,     0.0,
+                                0.0,     0.00001, 0.0,     0.0,     0.0,     0.0,
+                                0.0,     0.0,     10.0000, 0.0,     0.0,     0.0,
+                                0.0,     0.0,     0.0,     1.00000, 0.0,     0.0,
+                                0.0,     0.0,     0.0,     0.0,     1.00000, 0.0,
+                                0.0,     0.0,     0.0,     0.0,     0.0,     (velocityTheta == 0.0) ? 0.00000000001 : 1.00000};
+
+        //set the velocity
+        odom.twist.twist.linear.x = velocityX;
+        odom.twist.twist.angular.z = velocityTheta;
+
+        //publish the message
+        odomPublisher.publish(odom);
+
+        // broadcast transformation /tf
+        tf::Quaternion orientation = tf::Quaternion(odom.pose.pose.orientation.x,odom.pose.pose.orientation.y, odom.pose.pose.orientation.z, odom.pose.pose.orientation.w);
+        tf::Vector3 position = tf::Vector3(odom.pose.pose.position.x, odom.pose.pose.position.y, odom.pose.pose.position.z);
+        transformBroadcaster.sendTransform(tf::StampedTransform(tf::Transform(orientation, position), currTime, "odom", "base_footprint"));
+    }
+
+    lastLWheelPosition = currLWheelPosition;
+    lastRWheelPosition = currRWheelPosition;
+    lastTime = currTime;
+    isInitialized = true;
+}
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "brickpi3_odom_publisher"); // Name of this node.
+    BrickPi3OdomPublisher brickPi3OdomPublisher(argc, argv);
+    brickPi3OdomPublisher.run();
+}

--- a/brickpi3/src/BrickPi3OdomPublisher.cpp
+++ b/brickpi3/src/BrickPi3OdomPublisher.cpp
@@ -31,7 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <mutex>
 #include <stdio.h>
 #include <string>
-#include <Scheduler.h>
+#include "ext/Scheduler.h"
 #include <ros/ros.h>
 #include <ros/console.h>
 #include <sensor_msgs/JointState.h>

--- a/brickpi3/src/BrickPi3OdomPublisher_rx.cpp
+++ b/brickpi3/src/BrickPi3OdomPublisher_rx.cpp
@@ -1,0 +1,111 @@
+/*
+Copyright (c) 2019, ROSIN-project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <algorithm>
+#include <rxros.h>
+#include <sensor_msgs/JointState.h>
+#include <nav_msgs/Odometry.h>
+#include <geometry_msgs/Twist.h>
+#include <geometry_msgs/PoseWithCovariance.h>
+#include <geometry_msgs/Pose.h>
+#include <tf/transform_broadcaster.h>
+using namespace rxcpp::operators;
+using namespace rxros::operators;
+
+int main(int argc, char** argv)
+{
+    rxros::init(argc, argv, "brickpi3_odom_publisher"); // Name of this node.
+
+    const auto l_wheel_joint = rxros::parameter::get("/brickpi3/l_wheel_joint", "l_wheel_joint");
+    const auto r_wheel_joint = rxros::parameter::get("/brickpi3/r_wheel_joint", "r_wheel_joint");
+    const auto wheel_radius = rxros::parameter::get("/brickpi3/wheel_radius", 0.028); // m
+    const auto wheel_basis = rxros::parameter::get("/brickpi3/wheel_basis", 0.0625); // m
+
+    rxros::logging().info() << "brickpi3_odom_publisher:";
+    rxros::logging().info() << "l_wheel_joint: " << l_wheel_joint;
+    rxros::logging().info() << "r_wheel_joint: " << r_wheel_joint ;
+    rxros::logging().info() << "wheel_radius: " << wheel_radius ;
+    rxros::logging().info() << "wheel_basis: " << wheel_basis ;
+
+    auto stsTuple = [=](const auto& prevTuple, const auto& jointStates) {
+        const auto x = std::get<0>(prevTuple);
+        const auto y = std::get<1>(prevTuple);
+        const auto th = std::get<2>(prevTuple);
+        const auto last_lWheel_pos = std::get<5>(prevTuple);
+        const auto last_rWheel_pos = std::get<6>(prevTuple);
+        const auto last_time = std::get<7>(prevTuple);
+        const auto curr_time = ros::Time::now();
+        const auto curr_lWheel_pos = jointStates.position[0]; // first element is expected to be a left wheel
+        const auto curr_rWheel_pos = jointStates.position[1]; // second element is expected to be a right wheel
+        const auto delta_rWheel_pos = curr_rWheel_pos - last_rWheel_pos;
+        const auto delta_lWheel_pos = curr_lWheel_pos - last_lWheel_pos;
+        const auto velocity_x = (delta_rWheel_pos + delta_lWheel_pos) * wheel_radius / 2.0;
+        const auto velocity_y = 0.0;
+        const auto velocity_th = (delta_rWheel_pos - delta_lWheel_pos) * wheel_radius / (2.0 * wheel_basis);
+        const auto dt = (curr_time - last_time).toSec();
+        const auto dx = (velocity_x * cos(th) - velocity_y * sin(th)) * dt;
+        const auto dy = (velocity_x * sin(th) + velocity_y * cos(th)) * dt;
+        const auto dth = velocity_th * dt;
+        return std::make_tuple(x + dx, y + dy, th + dy, velocity_x, velocity_th, curr_lWheel_pos, curr_rWheel_pos, curr_time);};
+
+    auto stsTuple2Odometry = [](const auto& stsTuple) {  // stsTuple: x, y, theta θ, velocity x, velocity theta, left wheel pos, right wheel pos, current time
+        static std::atomic<unsigned int> seqNo(0);
+        const auto x = std::get<0>(stsTuple);
+        const auto y = std::get<1>(stsTuple);
+        const auto th = std::get<2>(stsTuple);
+        const auto velocity_x = std::get<3>(stsTuple);
+        const auto velocity_th = std::get<4>(stsTuple);
+        const auto curr_time = std::get<7>(stsTuple);
+        nav_msgs::Odometry odom;
+        odom.header.stamp = curr_time;
+        odom.header.seq = seqNo++;
+        odom.header.frame_id = "odom";
+        odom.child_frame_id = "base_footprint";
+        odom.pose.pose.position.x = x; //set the position
+        odom.pose.pose.position.y = y;
+        odom.pose.pose.position.z = 0.0;
+        odom.pose.pose.orientation = tf::createQuaternionMsgFromYaw(th);
+        odom.pose.covariance = {0.00001, 0.0,     0.0,     0.0,     0.0,     0.0,
+                                0.0,     0.00001, 0.0,     0.0,     0.0,     0.0,
+                                0.0,     0.0,     10.0000, 0.0,     0.0,     0.0,
+                                0.0,     0.0,     0.0,     1.00000, 0.0,     0.0,
+                                0.0,     0.0,     0.0,     0.0,     1.00000, 0.0,
+                                0.0,     0.0,     0.0,     0.0,     0.0,     (velocity_th == 0.0) ? 0.00000000001 : 1.00000};
+        odom.twist.twist.linear.x = velocity_x; //set the velocity
+        odom.twist.twist.angular.z = velocity_th;
+        return odom;};
+
+    rxros::observable::from_topic<sensor_msgs::JointState>("/joint_states")
+        | scan(std::make_tuple(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, ros::Time::now()), stsTuple) // tuple: x, y, theta θ, velocity x, velocity theta, left wheel pos, right wheel pos, current time
+        | map(stsTuple2Odometry)
+        | publish_to_topic<nav_msgs::Odometry>("/odom");
+
+    rxros::spin();
+}

--- a/brickpi3/src/BrickPi3OdomPublisher_rx.cpp
+++ b/brickpi3/src/BrickPi3OdomPublisher_rx.cpp
@@ -29,7 +29,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <algorithm>
-#include <rxros.h>
+#include <rxros/rxros.h>
 #include <sensor_msgs/JointState.h>
 #include <nav_msgs/Odometry.h>
 #include <geometry_msgs/Twist.h>

--- a/brickpi3/src/BrickPi3Ros.cpp
+++ b/brickpi3/src/BrickPi3Ros.cpp
@@ -1,0 +1,112 @@
+/*
+Copyright (c) 2019, ROSIN-project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <string>
+#include <iostream>
+#include <Scheduler.h>
+#include <boost/bind.hpp>
+#include <ros/ros.h>
+#include <ros/console.h>
+#include "Node.h"
+#include "BrickPi3Motor.h"
+#include "BrickPi3Ultrasonic.h"
+#include "BrickPi3Color.h"
+#include "BrickPi3Touch.h"
+
+class BrickPi3Ros {
+private:
+    Bosma::Scheduler scheduler;
+
+public:
+    BrickPi3Ros(int argc, char** argv);
+    virtual ~BrickPi3Ros() {}
+    void run() {ros::spin();}
+};
+
+BrickPi3Ros::BrickPi3Ros(int argc, char** argv):
+    scheduler(8) // BrickPi3 supports 8 devices.
+{
+    // Parse the ros_robot.yaml file and create the appropriate sensors and actuators
+    XmlRpc::XmlRpcValue brickpi3_robot;
+    Node::getHandle().getParam("/brickpi3/brickpi3_robot", brickpi3_robot);
+    ROS_ASSERT(brickpi3_robot.getType() == XmlRpc::XmlRpcValue::TypeArray);
+    std::cout << "---------------------------------" << std::endl;
+    for (int i = 0; i < brickpi3_robot.size(); i++) {
+        XmlRpc::XmlRpcValue brickpi3_device = brickpi3_robot[i];
+        std::string type = brickpi3_device["type"];
+        if (type == "motor") {
+            std::string name = brickpi3_device["name"];
+            std::string port = brickpi3_device["port"];
+            double freq = brickpi3_device["frequency"];
+            std::cout << type << ", " << name << ", " << port << ", " << freq << std::endl;
+
+            BrickPi3Motor* motor = new BrickPi3Motor(name, port, freq); //todo: Needs better resource handling. Should be freed when the BrickPi3Ros object is deleted.
+            scheduler.every(std::chrono::milliseconds(static_cast<int >(1000.0/freq)), boost::bind(&BrickPi3Motor::schedulerCB, motor));
+        }
+        else if (type == "ultrasonic") {
+            std::string name = brickpi3_device["name"];
+            std::string frame_id = brickpi3_device["frame_id"];
+            std::string port = brickpi3_device["port"];
+            double freq = brickpi3_device["frequency"];
+            double min_range = brickpi3_device["min_range"];
+            double max_range = brickpi3_device["max_range"];
+            double spread_angle = brickpi3_device["spread_angle"];
+
+            BrickPi3Ultrasonic* ultrasonic = new BrickPi3Ultrasonic(name, frame_id, port, freq, min_range, max_range, spread_angle); //todo: Needs better resource handling.
+            scheduler.every(std::chrono::milliseconds(static_cast<int >(1000.0/freq)), boost::bind(&BrickPi3Ultrasonic::schedulerCB, ultrasonic));
+        }
+        else if (type ==  "color")
+        {
+            std::string name = brickpi3_device["name"];
+            std::string frame_id = brickpi3_device["frame_id"];
+            std::string port = brickpi3_device["port"];
+            double freq = brickpi3_device["frequency"];
+
+            BrickPi3Color* color = new BrickPi3Color(name, frame_id, port, freq); //todo: Needs better resource handling.
+            scheduler.every(std::chrono::milliseconds(static_cast<int >(1000.0/freq)), boost::bind(&BrickPi3Color::schedulerCB, color));
+        }
+        else if (type == "touch")
+        {
+            std::string name = brickpi3_device["name"];
+            std::string frame_id = brickpi3_device["frame_id"];
+            std::string port = brickpi3_device["port"];
+            double freq = brickpi3_device["frequency"];
+
+            BrickPi3Touch* touch = new BrickPi3Touch(name, frame_id, port, freq); //todo: Needs better resource handling.
+            scheduler.every(std::chrono::milliseconds(static_cast<int >(1000.0/freq)), boost::bind(&BrickPi3Touch::schedulerCB, touch));
+        }
+    }
+}
+
+int main(int argc, char** argv) {
+    ros::init(argc, argv, "brickpi3"); // Name of this node.
+    BrickPi3Ros brickPi3Ros(argc, argv);
+    brickPi3Ros.run();
+}

--- a/brickpi3/src/BrickPi3Ros.cpp
+++ b/brickpi3/src/BrickPi3Ros.cpp
@@ -30,7 +30,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <string>
 #include <iostream>
-#include <Scheduler.h>
+#include "ext/Scheduler.h"
 #include <boost/bind.hpp>
 #include <ros/ros.h>
 #include <ros/console.h>

--- a/brickpi3/src/BrickPi3Ros_rx.cpp
+++ b/brickpi3/src/BrickPi3Ros_rx.cpp
@@ -1,0 +1,158 @@
+/*
+Copyright (c) 2019, ROSIN-project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <rxros.h>
+#include <sensor_msgs/JointState.h>
+#include <brickpi3_msgs/Contact.h>
+#include <brickpi3_msgs/Color.h>
+#include <brickpi3_msgs/Range.h>
+#include <brickpi3_msgs/JointCommand.h>
+#include "BrickPi3Utils.h"
+#include "BrickPi3Observable_rx.h"
+using namespace rxcpp::operators;
+using namespace rxros::operators;
+using namespace brickpi3::operators;
+
+
+template <class Observable>
+auto join_with_latest_from(const Observable& observable) {
+    return [=](auto&& source) {
+        return source.with_latest_from (
+            [=](const auto o1, const auto o2) {
+                return std::make_tuple(o1, o2);}, observable);};}
+
+
+int main(int argc, char** argv) {
+    rxros::init(argc, argv, "brickpi3"); // Name of this node.
+
+    auto touchEvent2ContactMsg = [] (const std::string& frameId) {
+        return [=](const sensor_touch_t& touchEvent) {
+            static int seqNo = 0;
+            brickpi3_msgs::Contact contact;
+            contact.header.frame_id = frameId;
+            contact.header.stamp = ros::Time::now();
+            contact.header.seq = seqNo++;
+            contact.contact = touchEvent.pressed;
+            return contact;};};
+
+    auto colorEvent2ColorMsg = [] (const std::string& frameId) {
+        return [=](const sensor_color_t& colorEvent) {
+            static int seqNo = 0;
+            brickpi3_msgs::Color color;
+            color.header.frame_id = frameId;
+            color.header.stamp = ros::Time::now();
+            color.header.seq = seqNo++;
+            color.r = static_cast<double>(colorEvent.reflected_red);
+            color.g = static_cast<double>(colorEvent.reflected_green);
+            color.b = static_cast<double>(colorEvent.reflected_blue);
+            color.intensity = static_cast<double>(colorEvent.ambient);
+            return color;};};
+
+    auto ultrasonicEvent2RangeMsg = [] (const std::string& frameId, const double minRange, const double maxRange, const double spreadAngle) {
+        return [=](const sensor_ultrasonic_t& ultrasonicEvent) {
+            static int seqNo = 0;
+            brickpi3_msgs::Range range;
+            range.header.frame_id = frameId;
+            range.header.stamp = ros::Time::now();
+            range.header.seq = seqNo++;
+            range.range = ultrasonicEvent.cm / 100.0;
+            range.range_min = minRange;
+            range.range_max = maxRange;
+            range.spread_angle = spreadAngle;
+            return range;};};
+
+    auto motorEvent2PosVelTimeTuple = [](const auto& prevPosVelTimeTuple, const actuator_motor_t& motorEvent) {
+        const auto prevTime = std::get<0>(prevPosVelTimeTuple);
+        const auto prevPos = std::get<1>(prevPosVelTimeTuple);
+        const auto prevVel = std::get<2>(prevPosVelTimeTuple);
+        const auto currTime = ros::Time::now();
+        const auto currPos = static_cast<double>(motorEvent.motorPosition) * M_PI / 180.0 / 3.0; // 3.0 is gearing ratio
+        const auto currVel = (currPos - prevPos)/(currTime - prevTime).toSec();
+        return std::make_tuple(currTime, currPos, currVel);};
+
+    auto posVelTimeTuple2JointStateMsg = [](const std::string& name) {
+        return [=](const auto& tuple) {
+            static int seqNo = 0;
+            const auto posVelTimeTuple = std::get<0>(tuple);
+            const auto position = std::get<1>(posVelTimeTuple);
+            const auto velocity = std::get<2>(posVelTimeTuple);
+            const auto effort = std::get<1>(tuple).effort;
+            sensor_msgs::JointState jointState;
+            //jointState.header.frame_id = name;
+            jointState.header.stamp = ros::Time::now();
+            jointState.header.seq = seqNo++;
+            jointState.name.push_back(name);
+            jointState.effort.push_back(effort);
+            jointState.position.push_back(position); // rad
+            jointState.velocity.push_back(velocity); // rad/s
+            return jointState;};};
+
+    auto jointCmdObserv = rxros::observable::from_topic<brickpi3_msgs::JointCommand>("/joint_command");
+
+    rxros::observable::from_yaml("/brickpi3/brickpi3_robot").subscribe(
+        [=](auto config) { // on_next event
+            DeviceConfig device(config);
+            if (device.getType() == "motor") {
+                rxros::logging().debug() << device.getType() << ", " << device.getName() << ", " << device.getPort() << ", " << device.getFrequency();
+
+                brickpi3::observable::motor(device.getName(), device.getPort(), device.getFrequency())
+                | scan(std::make_tuple(ros::Time::now(), 0.0, 0.0), motorEvent2PosVelTimeTuple)
+                | join_with_latest_from(
+                    jointCmdObserv
+                    | filter([=](const auto& jointCmd){ return (jointCmd.name == device.getName()); })
+                    | set_motor_power(device.getPort()))
+                | map(posVelTimeTuple2JointStateMsg(device.getName()))
+                | publish_to_topic<sensor_msgs::JointState>("/joint_state");
+            }
+            else if (device.getType() == "ultrasonic") {
+                rxros::logging().debug() << device.getType() << ", " << device.getName() << ", " << device.getPort() << ", " << device.getFrequency();
+
+                brickpi3::observable::ultrasonic_sensor(device.getName(), device.getPort(), device.getFrequency())
+                | map(ultrasonicEvent2RangeMsg(device.getFrameId(), device.getMinRange(), device.getMaxRange(), device.getSpreadAngle()))
+                | publish_to_topic<brickpi3_msgs::Range>("/" + device.getName());
+            }
+            else if (device.getType() == "color") {
+                rxros::logging().debug() << device.getType() << ", " << device.getName() << ", " << device.getPort() << ", " << device.getFrequency();
+
+                brickpi3::observable::color_sensor(device.getName(), device.getPort(), device.getFrequency())
+                | map(colorEvent2ColorMsg(device.getFrameId()))
+                | publish_to_topic<brickpi3_msgs::Color>("/" + device.getName());
+            }
+            else if (device.getType() == "touch") {
+                rxros::logging().debug() << device.getType() << ", " << device.getName() << ", " << device.getPort() << ", " << device.getFrequency();
+
+                brickpi3::observable::touch_sensor(device.getName(), device.getPort(), device.getFrequency())
+                | map(touchEvent2ContactMsg(device.getFrameId()))
+                | publish_to_topic<brickpi3_msgs::Contact>("/" + device.getName());
+            }},
+        [](){}); // on completed event
+
+    rxros::spin();
+}

--- a/brickpi3/src/BrickPi3Ros_rx.cpp
+++ b/brickpi3/src/BrickPi3Ros_rx.cpp
@@ -28,7 +28,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <rxros.h>
+#include <rxros/rxros.h>
 #include <sensor_msgs/JointState.h>
 #include <brickpi3_msgs/Contact.h>
 #include <brickpi3_msgs/Color.h>

--- a/brickpi3/src/BrickPi3Touch.cpp
+++ b/brickpi3/src/BrickPi3Touch.cpp
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2019, ROSIN-project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <string>
+#include <iostream>
+#include <brickpi3_msgs/Contact.h>
+#include "Node.h"
+#include "BrickPi3Touch.h"
+
+
+BrickPi3Touch::BrickPi3Touch(const std::string& aName, const std::string& aFrameId, const std::string& aPort, const double aFrequency):
+    touchPublisher(Node::getHandle().advertise<brickpi3_msgs::Contact>("/" + aName, 10))
+{
+    name = aName;
+    frameId = aFrameId;
+    port = port2id(aPort);
+    freq = aFrequency;
+    seqNo = 0;
+
+    brickPi3.set_sensor_type(port, SENSOR_TYPE_TOUCH_NXT);
+}
+
+
+void BrickPi3Touch::schedulerCB()
+{
+    std::lock_guard<std::mutex> guard(mutex);
+
+    sensor_touch_t sensorTouch;
+    int rc = brickPi3.get_sensor(port, &sensorTouch);
+    if (rc == 0) {
+        ROS_DEBUG("Touch sensor: pressed %s", (sensorTouch.pressed) ? "True" : "False");
+
+        brickpi3_msgs::Contact contact;
+        contact.header.frame_id = frameId;
+        contact.header.stamp = ros::Time::now();
+        contact.header.seq = seqNo++;
+        contact.contact = sensorTouch.pressed;
+
+        touchPublisher.publish(contact);
+    }
+    else {
+        ROS_ERROR("BrickPi3 failed to read Color sensor %s, rc %d", name.c_str(), rc);
+    }
+}

--- a/brickpi3/src/BrickPi3Touch.h
+++ b/brickpi3/src/BrickPi3Touch.h
@@ -1,0 +1,63 @@
+/*
+Copyright (c) 2019, ROSIN-project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef BRICKPI3_BRICKPI3TOUCH_H
+#define BRICKPI3_BRICKPI3TOUCH_H
+
+#include <string>
+#include <ros/ros.h>
+#include <ros/console.h>
+#include "BrickPi3Device.h"
+
+
+class BrickPi3Touch: public BrickPi3Device
+{
+private:
+    ros::Publisher touchPublisher;
+    std::string name;
+    std::string frameId;
+    uint8_t port;
+    double freq;
+    unsigned int seqNo;
+
+public:
+    BrickPi3Touch(const std::string& name, const std::string& frameId, const std::string& port, const double frequency);
+    virtual ~BrickPi3Touch() {}
+
+    const std::string& getName() const {return name;}
+    const std::string& getFrameId() const {return frameId;}
+    const uint8_t getPort() const {return port;}
+    const double getFreq() const {return freq;}
+
+    void schedulerCB();
+};
+
+
+#endif //BRICKPI3_BRICKPI3TOUCH_H

--- a/brickpi3/src/BrickPi3Ultrasonic.cpp
+++ b/brickpi3/src/BrickPi3Ultrasonic.cpp
@@ -1,0 +1,77 @@
+/*
+Copyright (c) 2019, ROSIN-project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <string>
+#include <iostream>
+#include <ros/ros.h>
+#include <brickpi3_msgs/Range.h>
+#include "Node.h"
+#include "BrickPi3Ultrasonic.h"
+using namespace std;
+
+
+BrickPi3Ultrasonic::BrickPi3Ultrasonic(const std::string& aName, const std::string& aFrameId,const std::string& aPort, const double aFrequency, const double aMinRange, const double aMaxRange, const double aSpreadAngle):
+    ultrasonicPublisher(Node::getHandle().advertise<brickpi3_msgs::Range>("/" + aName, 10))
+{
+    name = aName;
+    frameId = aFrameId;
+    port = port2id(aPort);
+    freq = aFrequency;
+    minRange = aMinRange;
+    maxRange = aMaxRange;
+    spreadAngle = aSpreadAngle;
+    seqNo = 0;
+
+    brickPi3.set_sensor_type(port, SENSOR_TYPE_NXT_ULTRASONIC);
+}
+
+
+void BrickPi3Ultrasonic::schedulerCB()
+{
+    sensor_ultrasonic_t sensorUltrasonic;
+    int rc = brickPi3.get_sensor(port, &sensorUltrasonic);
+    if (rc == 0) {
+        ROS_DEBUG("Ultrasonic sensor: CM %5.1f Inches %5.1f", sensorUltrasonic.cm, sensorUltrasonic.inch);
+
+        brickpi3_msgs::Range range;
+        range.header.frame_id = frameId;
+        range.header.stamp = ros::Time::now();
+        range.header.seq = seqNo++;
+        range.range = sensorUltrasonic.cm / 100.0;
+        range.range_min = minRange;
+        range.range_max = maxRange;
+        range.spread_angle = spreadAngle;
+
+        ultrasonicPublisher.publish(range);
+    }
+    else {
+        ROS_ERROR("BrickPi3 failed to read Ultrasonic sensor %s, rc %d", name.c_str(), rc);
+    }
+}

--- a/brickpi3/src/BrickPi3Ultrasonic.h
+++ b/brickpi3/src/BrickPi3Ultrasonic.h
@@ -1,0 +1,69 @@
+/*
+Copyright (c) 2019, ROSIN-project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef BRICKPI3_BRICKPI3ULTRASONIC_H
+#define BRICKPI3_BRICKPI3ULTRASONIC_H
+
+#include <string>
+#include <ros/ros.h>
+#include <ros/console.h>
+#include "BrickPi3Device.h"
+
+
+class BrickPi3Ultrasonic: public BrickPi3Device
+{
+private:
+    ros::Publisher ultrasonicPublisher;
+    std::string name;
+    std::string frameId;
+    uint8_t port;
+    double freq;
+    double minRange;
+    double maxRange;
+    double spreadAngle;
+    unsigned int seqNo;
+
+public:
+    BrickPi3Ultrasonic(const std::string& name, const std::string& frameId,const std::string& port, const double frequency, const double minRange, const double maxRange, const double spreadAngle);
+    virtual ~BrickPi3Ultrasonic() {}
+
+    const std::string &getName() const {return name;}
+    const std::string &getFrameId() const {return frameId;}
+    const uint8_t &getPort() const {return port;}
+    double getFreq() const {return freq;}
+    double getMinRange() const {return minRange;}
+    double getMaxRange() const {return maxRange;}
+    double getSpreadAngle() const {return spreadAngle;}
+
+    void schedulerCB();
+};
+
+
+#endif //BRICKPI3_BRICKPI3ULTRASONIC_H

--- a/brickpi3/src/BrickPi3Utils.h
+++ b/brickpi3/src/BrickPi3Utils.h
@@ -1,0 +1,72 @@
+/*
+Copyright (c) 2019, ROSIN-project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef RXCPP_LANG_BRICKPI3UTILS_H
+#define RXCPP_LANG_BRICKPI3UTILS_H
+
+#include <ros/ros.h>
+
+// Support class to simplify access to configuration parameters for device
+class DeviceConfig
+{
+private:
+    std::string type;
+    std::string name;
+    std::string frameId;
+    std::string port;
+    double frequency;
+    double minRange;
+    double maxRange;
+    double spreadAngle;
+
+public:
+    explicit DeviceConfig(XmlRpc::XmlRpcValue& value) {
+        type = value.hasMember("type") ? (std::string) value["type"] : std::string("");
+        name = value.hasMember("name") ? (std::string) value["name"] : std::string("");
+        frameId = value.hasMember("frame_id") ? (std::string) value["frame_id"] : std::string("");
+        port = value.hasMember("port") ? (std::string) value["port"] : std::string("");
+        frequency = value.hasMember("frequency") ? (double) value["frequency"] : 0.0;
+        minRange = value.hasMember("min_range") ? (double) value["min_range"] : 0.0;
+        maxRange = value.hasMember("max_range") ? (double) value["max_range"] : 0.0;
+        spreadAngle = value.hasMember("spread_angle") ? (double) value["spread_angle"] : 0.0;
+    }
+    ~DeviceConfig() = default;
+
+    const std::string& getType() const {return type;}
+    const std::string& getName() const {return name;}
+    const std::string& getFrameId() const {return frameId;}
+    const std::string& getPort() const {return port;}
+    double getFrequency() const {return frequency;}
+    double getMinRange() const { return minRange;}
+    double getMaxRange() const { return  maxRange;}
+    double getSpreadAngle() const { return spreadAngle;}
+};
+
+#endif //RXCPP_LANG_BRICKPI3UTILS_H

--- a/brickpi3/src/Node.h
+++ b/brickpi3/src/Node.h
@@ -1,0 +1,50 @@
+/*
+Copyright (c) 2019, ROSIN-project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef BRICKPI3_NODE_H
+#define BRICKPI3_NODE_H
+
+#include <ros/ros.h>
+
+class Node
+{
+private:
+    Node() = default;
+
+public:
+    ~Node() = default;
+
+    static ros::NodeHandle& getHandle() {
+        static ros::NodeHandle nodehandle;
+        return nodehandle;
+    }
+};
+
+#endif //BRICKPI3_NODE_H

--- a/brickpi3/src/ext/Cron.h
+++ b/brickpi3/src/ext/Cron.h
@@ -1,0 +1,121 @@
+#include <chrono>
+#include <string>
+#include <sstream>
+#include <vector>
+#include <iterator>
+
+namespace Bosma {
+    using Clock = std::chrono::system_clock;
+
+    inline void add(std::tm &tm, Clock::duration time) {
+      auto tp = Clock::from_time_t(std::mktime(&tm));
+      auto tp_adjusted = tp + time;
+      auto tm_adjusted = Clock::to_time_t(tp_adjusted);
+      tm = *std::localtime(&tm_adjusted);
+    }
+
+    class BadCronExpression : public std::exception {
+    public:
+        explicit BadCronExpression(std::string msg) : msg_(std::move(msg)) {}
+
+        const char *what() const noexcept override { return (msg_.c_str()); }
+
+    private:
+        std::string msg_;
+    };
+
+    inline void
+    verify_and_set(const std::string &token, const std::string &expression, int &field, const int lower_bound,
+                   const int upper_bound, const bool adjust = false) {
+      if (token == "*")
+        field = -1;
+      else {
+        try {
+          field = std::stoi(token);
+        } catch (const std::invalid_argument &) {
+          throw BadCronExpression("malformed cron string (`" + token + "` not an integer or *): " + expression);
+        } catch (const std::out_of_range &) {
+          throw BadCronExpression("malformed cron string (`" + token + "` not convertable to int): " + expression);
+        }
+        if (field < lower_bound || field > upper_bound) {
+          std::ostringstream oss;
+          oss << "malformed cron string ('" << token << "' must be <= " << upper_bound << " and >= " << lower_bound
+              << "): " << expression;
+          throw BadCronExpression(oss.str());
+        }
+        if (adjust)
+          field--;
+      }
+    }
+
+    class Cron {
+    public:
+        explicit Cron(const std::string &expression) {
+          std::istringstream iss(expression);
+          std::vector<std::string> tokens{std::istream_iterator<std::string>{iss},
+                                          std::istream_iterator<std::string>{}};
+
+          if (tokens.size() != 5) throw BadCronExpression("malformed cron string (must be 5 fields): " + expression);
+
+          verify_and_set(tokens[0], expression, minute, 0, 59);
+          verify_and_set(tokens[1], expression, hour, 0, 23);
+          verify_and_set(tokens[2], expression, day, 1, 31);
+          verify_and_set(tokens[3], expression, month, 1, 12, true);
+          verify_and_set(tokens[4], expression, day_of_week, 0, 6);
+        }
+
+        // http://stackoverflow.com/a/322058/1284550
+        Clock::time_point cron_to_next(const Clock::time_point from = Clock::now()) const {
+          // get current time as a tm object
+          auto now = Clock::to_time_t(from);
+          std::tm next(*std::localtime(&now));
+          // it will always at least run the next minute
+          next.tm_sec = 0;
+          add(next, std::chrono::minutes(1));
+          while (true) {
+            if (month != -1 && next.tm_mon != month) {
+              // add a month
+              // if this will bring us over a year, increment the year instead and reset the month
+              if (next.tm_mon + 1 > 11) {
+                next.tm_mon = 0;
+                next.tm_year++;
+              } else
+                next.tm_mon++;
+
+              next.tm_mday = 1;
+              next.tm_hour = 0;
+              next.tm_min = 0;
+              continue;
+            }
+            if (day != -1 && next.tm_mday != day) {
+              add(next, std::chrono::hours(24));
+              next.tm_hour = 0;
+              next.tm_min = 0;
+              continue;
+            }
+            if (day_of_week != -1 && next.tm_wday != day_of_week) {
+              add(next, std::chrono::hours(24));
+              next.tm_hour = 0;
+              next.tm_min = 0;
+              continue;
+            }
+            if (hour != -1 && next.tm_hour != hour) {
+              add(next, std::chrono::hours(1));
+              next.tm_min = 0;
+              continue;
+            }
+            if (minute != -1 && next.tm_min != minute) {
+              add(next, std::chrono::minutes(1));
+              continue;
+            }
+            break;
+          }
+
+          // telling mktime to figure out dst
+          next.tm_isdst = -1;
+          return Clock::from_time_t(std::mktime(&next));
+        }
+
+        int minute, hour, day, month, day_of_week;
+    };
+}

--- a/brickpi3/src/ext/InterruptableSleep.h
+++ b/brickpi3/src/ext/InterruptableSleep.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <chrono>
+#include <thread>
+#include <future>
+#include <mutex>
+#include <sstream>
+
+namespace Bosma {
+    class InterruptableSleep {
+
+        using Clock = std::chrono::system_clock;
+
+        // InterruptableSleep offers a sleep that can be interrupted by any thread.
+        // It can be interrupted multiple times
+        // and be interrupted before any sleep is called (the sleep will immediately complete)
+        // Has same interface as condition_variables and futures, except with sleep instead of wait.
+        // For a given object, sleep can be called on multiple threads safely, but is not recommended as behaviour is undefined.
+
+    public:
+        InterruptableSleep() : interrupted(false) {
+        }
+
+        InterruptableSleep(const InterruptableSleep &) = delete;
+
+        InterruptableSleep(InterruptableSleep &&) noexcept = delete;
+
+        ~InterruptableSleep() noexcept = default;
+
+        InterruptableSleep &operator=(const InterruptableSleep &) noexcept = delete;
+
+        InterruptableSleep &operator=(InterruptableSleep &&) noexcept = delete;
+
+        void sleep_for(Clock::duration duration) {
+          std::unique_lock<std::mutex> ul(m);
+          cv.wait_for(ul, duration, [this] { return interrupted; });
+          interrupted = false;
+        }
+
+        void sleep_until(Clock::time_point time) {
+          std::unique_lock<std::mutex> ul(m);
+          cv.wait_until(ul, time, [this] { return interrupted; });
+          interrupted = false;
+        }
+
+        void sleep() {
+          std::unique_lock<std::mutex> ul(m);
+          cv.wait(ul, [this] { return interrupted; });
+          interrupted = false;
+        }
+
+        void interrupt() {
+          std::lock_guard<std::mutex> lg(m);
+          interrupted = true;
+          cv.notify_one();
+        }
+
+    private:
+        bool interrupted;
+        std::mutex m;
+        std::condition_variable cv;
+    };
+}

--- a/brickpi3/src/ext/Scheduler.h
+++ b/brickpi3/src/ext/Scheduler.h
@@ -1,0 +1,221 @@
+#pragma once
+
+#include <iomanip>
+#include <map>
+
+#include "ctpl_stl.h"
+
+#include "InterruptableSleep.h"
+#include "Cron.h"
+
+namespace Bosma {
+    using Clock = std::chrono::system_clock;
+
+    class Task {
+    public:
+        explicit Task(std::function<void()> &&f, bool recur = false, bool interval = false) :
+                f(std::move(f)), recur(recur), interval(interval) {}
+
+        virtual Clock::time_point get_new_time() const = 0;
+
+        std::function<void()> f;
+
+        bool recur;
+        bool interval;
+    };
+
+    class InTask : public Task {
+    public:
+        explicit InTask(std::function<void()> &&f) : Task(std::move(f)) {}
+
+        // dummy time_point because it's not used
+        Clock::time_point get_new_time() const override { return Clock::time_point(Clock::duration(0)); }
+    };
+
+    class EveryTask : public Task {
+    public:
+        EveryTask(Clock::duration time, std::function<void()> &&f, bool interval = false) :
+                Task(std::move(f), true, interval), time(time) {}
+
+        Clock::time_point get_new_time() const override {
+          return Clock::now() + time;
+        };
+        Clock::duration time;
+    };
+
+    class CronTask : public Task {
+    public:
+        CronTask(const std::string &expression, std::function<void()> &&f) : Task(std::move(f), true),
+                                                                             cron(expression) {}
+
+        Clock::time_point get_new_time() const override {
+          return cron.cron_to_next();
+        };
+        Cron cron;
+    };
+
+    inline bool try_parse(std::tm &tm, const std::string &expression, const std::string &format) {
+      std::stringstream ss(expression);
+      return !(ss >> std::get_time(&tm, format.c_str())).fail();
+    }
+
+    class Scheduler {
+    public:
+        explicit Scheduler(unsigned int max_n_tasks = 4) : done(false), threads(max_n_tasks + 1) {
+          threads.push([this](int) {
+              while (!done) {
+                if (tasks.empty()) {
+                  sleeper.sleep();
+                } else {
+                  auto time_of_first_task = (*tasks.begin()).first;
+                  sleeper.sleep_until(time_of_first_task);
+                }
+                manage_tasks();
+              }
+          });
+        }
+
+        Scheduler(const Scheduler &) = delete;
+
+        Scheduler(Scheduler &&) noexcept = delete;
+
+        Scheduler &operator=(const Scheduler &) = delete;
+
+        Scheduler &operator=(Scheduler &&) noexcept = delete;
+
+        ~Scheduler() {
+          done = true;
+          sleeper.interrupt();
+        }
+
+        template<typename _Callable, typename... _Args>
+        void in(const Clock::time_point time, _Callable &&f, _Args &&... args) {
+          std::shared_ptr<Task> t = std::make_shared<InTask>(
+                  std::bind(std::forward<_Callable>(f), std::forward<_Args>(args)...));
+          add_task(time, std::move(t));
+        }
+
+        template<typename _Callable, typename... _Args>
+        void in(const Clock::duration time, _Callable &&f, _Args &&... args) {
+          in(Clock::now() + time, std::forward<_Callable>(f), std::forward<_Args>(args)...);
+        }
+
+        template<typename _Callable, typename... _Args>
+        void at(const std::string &time, _Callable &&f, _Args &&... args) {
+          // get current time as a tm object
+          auto time_now = Clock::to_time_t(Clock::now());
+          std::tm tm = *std::localtime(&time_now);
+
+          // our final time as a time_point
+          Clock::time_point tp;
+
+          if (try_parse(tm, time, "%H:%M:%S")) {
+            // convert tm back to time_t, then to a time_point and assign to final
+            tp = Clock::from_time_t(std::mktime(&tm));
+
+            // if we've already passed this time, the user will mean next day, so add a day.
+            if (Clock::now() >= tp)
+              tp += std::chrono::hours(24);
+          } else if (try_parse(tm, time, "%Y-%m-%d %H:%M:%S")) {
+            tp = Clock::from_time_t(std::mktime(&tm));
+          } else if (try_parse(tm, time, "%Y/%m/%d %H:%M:%S")) {
+            tp = Clock::from_time_t(std::mktime(&tm));
+          } else {
+            // could not parse time
+            throw std::runtime_error("Cannot parse time string: " + time);
+          }
+
+          in(tp, std::forward<_Callable>(f), std::forward<_Args>(args)...);
+        }
+
+        template<typename _Callable, typename... _Args>
+        void every(const Clock::duration time, _Callable &&f, _Args &&... args) {
+          std::shared_ptr<Task> t = std::make_shared<EveryTask>(time, std::bind(std::forward<_Callable>(f),
+                                                                                std::forward<_Args>(args)...));
+          auto next_time = t->get_new_time();
+          add_task(next_time, std::move(t));
+        }
+
+// expression format:
+// from https://en.wikipedia.org/wiki/Cron#Overview
+//    ┌───────────── minute (0 - 59)
+//    │ ┌───────────── hour (0 - 23)
+//    │ │ ┌───────────── day of month (1 - 31)
+//    │ │ │ ┌───────────── month (1 - 12)
+//    │ │ │ │ ┌───────────── day of week (0 - 6) (Sunday to Saturday)
+//    │ │ │ │ │
+//    │ │ │ │ │
+//    * * * * *
+        template<typename _Callable, typename... _Args>
+        void cron(const std::string &expression, _Callable &&f, _Args &&... args) {
+          std::shared_ptr<Task> t = std::make_shared<CronTask>(expression, std::bind(std::forward<_Callable>(f),
+                                                                                     std::forward<_Args>(args)...));
+          auto next_time = t->get_new_time();
+          add_task(next_time, std::move(t));
+        }
+
+        template<typename _Callable, typename... _Args>
+        void interval(const Clock::duration time, _Callable &&f, _Args &&... args) {
+          std::shared_ptr<Task> t = std::make_shared<EveryTask>(time, std::bind(std::forward<_Callable>(f),
+                                                                                std::forward<_Args>(args)...), true);
+          add_task(Clock::now(), std::move(t));
+        }
+
+    private:
+        std::atomic<bool> done;
+
+        Bosma::InterruptableSleep sleeper;
+
+        std::multimap<Clock::time_point, std::shared_ptr<Task>> tasks;
+        std::mutex lock;
+        ctpl::thread_pool threads;
+
+        void add_task(const Clock::time_point time, std::shared_ptr<Task> t) {
+          std::lock_guard<std::mutex> l(lock);
+          tasks.emplace(time, std::move(t));
+          sleeper.interrupt();
+        }
+
+        void manage_tasks() {
+          std::lock_guard<std::mutex> l(lock);
+
+          auto end_of_tasks_to_run = tasks.upper_bound(Clock::now());
+
+          // if there are any tasks to be run and removed
+          if (end_of_tasks_to_run != tasks.begin()) {
+            // keep track of tasks that will be re-added
+            decltype(tasks) recurred_tasks;
+
+            // for all tasks that have been triggered
+            for (auto i = tasks.begin(); i != end_of_tasks_to_run; ++i) {
+
+              auto &task = (*i).second;
+
+              if (task->interval) {
+                // if it's an interval task, only add the task back after f() is completed
+                threads.push([this, task](int) {
+                    task->f();
+                    // no risk of race-condition,
+                    // add_task() will wait for manage_tasks() to release lock
+                    add_task(task->get_new_time(), task);
+                });
+              } else {
+                threads.push([task](int) {
+                    task->f();
+                });
+                // calculate time of next run and add the new task to the tasks to be recurred
+                if (task->recur)
+                  recurred_tasks.emplace(task->get_new_time(), std::move(task));
+              }
+            }
+
+            // remove the completed tasks
+            tasks.erase(tasks.begin(), end_of_tasks_to_run);
+
+            // re-add the tasks that are recurring
+            for (auto &task : recurred_tasks)
+              tasks.emplace(task.first, std::move(task.second));
+          }
+        }
+    };
+}

--- a/brickpi3/src/ext/ctpl.h
+++ b/brickpi3/src/ext/ctpl.h
@@ -1,0 +1,240 @@
+
+/*********************************************************
+ *
+ *  Copyright (C) 2014 by Vitaliy Vitsentiy
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *********************************************************/
+
+
+#ifndef __ctpl_thread_pool_H__
+#define __ctpl_thread_pool_H__
+
+#include <functional>
+#include <thread>
+#include <atomic>
+#include <vector>
+#include <memory>
+#include <exception>
+#include <future>
+#include <mutex>
+#include <boost/lockfree/queue.hpp>
+
+
+#ifndef _ctplThreadPoolLength_
+#define _ctplThreadPoolLength_  100
+#endif
+
+
+// thread pool to run user's functors with signature
+//      ret func(int id, other_params)
+// where id is the index of the thread that runs the functor
+// ret is some return type
+
+
+namespace ctpl {
+
+    class thread_pool {
+
+    public:
+
+        thread_pool() : q(_ctplThreadPoolLength_) { this->init(); }
+        thread_pool(int nThreads, int queueSize = _ctplThreadPoolLength_) : q(queueSize) { this->init(); this->resize(nThreads); }
+
+        // the destructor waits for all the functions in the queue to be finished
+        ~thread_pool() {
+            this->stop(true);
+        }
+
+        // get the number of running threads in the pool
+        int size() { return static_cast<int>(this->threads.size()); }
+
+        // number of idle threads
+        int n_idle() { return this->nWaiting; }
+        std::thread & get_thread(int i) { return *this->threads[i]; }
+
+        // change the number of threads in the pool
+        // should be called from one thread, otherwise be careful to not interleave, also with this->stop()
+        // nThreads must be >= 0
+        void resize(int nThreads) {
+            if (!this->isStop && !this->isDone) {
+                int oldNThreads = static_cast<int>(this->threads.size());
+                if (oldNThreads <= nThreads) {  // if the number of threads is increased
+                    this->threads.resize(nThreads);
+                    this->flags.resize(nThreads);
+
+                    for (int i = oldNThreads; i < nThreads; ++i) {
+                        this->flags[i] = std::make_shared<std::atomic<bool>>(false);
+                        this->set_thread(i);
+                    }
+                }
+                else {  // the number of threads is decreased
+                    for (int i = oldNThreads - 1; i >= nThreads; --i) {
+                        *this->flags[i] = true;  // this thread will finish
+                        this->threads[i]->detach();
+                    }
+                    {
+                        // stop the detached threads that were waiting
+                        std::unique_lock<std::mutex> lock(this->mutex);
+                        this->cv.notify_all();
+                    }
+                    this->threads.resize(nThreads);  // safe to delete because the threads are detached
+                    this->flags.resize(nThreads);  // safe to delete because the threads have copies of shared_ptr of the flags, not originals
+                }
+            }
+        }
+
+        // empty the queue
+        void clear_queue() {
+            std::function<void(int id)> * _f;
+            while (this->q.pop(_f))
+                delete _f;  // empty the queue
+        }
+
+        // pops a functional wraper to the original function
+        std::function<void(int)> pop() {
+            std::function<void(int id)> * _f = nullptr;
+            this->q.pop(_f);
+            std::unique_ptr<std::function<void(int id)>> func(_f);  // at return, delete the function even if an exception occurred
+            
+            std::function<void(int)> f;
+            if (_f)
+                f = *_f;
+            return f;
+        }
+
+
+        // wait for all computing threads to finish and stop all threads
+        // may be called asyncronously to not pause the calling thread while waiting
+        // if isWait == true, all the functions in the queue are run, otherwise the queue is cleared without running the functions
+        void stop(bool isWait = false) {
+            if (!isWait) {
+                if (this->isStop)
+                    return;
+                this->isStop = true;
+                for (int i = 0, n = this->size(); i < n; ++i) {
+                    *this->flags[i] = true;  // command the threads to stop
+                }
+                this->clear_queue();  // empty the queue
+            }
+            else {
+                if (this->isDone || this->isStop)
+                    return;
+                this->isDone = true;  // give the waiting threads a command to finish
+            }
+            {
+                std::unique_lock<std::mutex> lock(this->mutex);
+                this->cv.notify_all();  // stop all waiting threads
+            }
+            for (int i = 0; i < static_cast<int>(this->threads.size()); ++i) {  // wait for the computing threads to finish
+                if (this->threads[i]->joinable())
+                    this->threads[i]->join();
+            }
+            // if there were no threads in the pool but some functors in the queue, the functors are not deleted by the threads
+            // therefore delete them here
+            this->clear_queue();
+            this->threads.clear();
+            this->flags.clear();
+        }
+
+        template<typename F, typename... Rest>
+        auto push(F && f, Rest&&... rest) ->std::future<decltype(f(0, rest...))> {
+            auto pck = std::make_shared<std::packaged_task<decltype(f(0, rest...))(int)>>(
+                std::bind(std::forward<F>(f), std::placeholders::_1, std::forward<Rest>(rest)...)
+            );
+
+            auto _f = new std::function<void(int id)>([pck](int id) {
+                (*pck)(id);
+            });
+            this->q.push(_f);
+
+            std::unique_lock<std::mutex> lock(this->mutex);
+            this->cv.notify_one();
+
+            return pck->get_future();
+        }
+
+        // run the user's function that excepts argument int - id of the running thread. returned value is templatized
+        // operator returns std::future, where the user can get the result and rethrow the catched exceptins
+        template<typename F>
+        auto push(F && f) ->std::future<decltype(f(0))> {
+            auto pck = std::make_shared<std::packaged_task<decltype(f(0))(int)>>(std::forward<F>(f));
+
+            auto _f = new std::function<void(int id)>([pck](int id) {
+                (*pck)(id);
+            });
+            this->q.push(_f);
+
+            std::unique_lock<std::mutex> lock(this->mutex);
+            this->cv.notify_one();
+
+            return pck->get_future();
+        }
+
+
+    private:
+
+        // deleted
+        thread_pool(const thread_pool &);// = delete;
+        thread_pool(thread_pool &&);// = delete;
+        thread_pool & operator=(const thread_pool &);// = delete;
+        thread_pool & operator=(thread_pool &&);// = delete;
+
+        void set_thread(int i) {
+            std::shared_ptr<std::atomic<bool>> flag(this->flags[i]);  // a copy of the shared ptr to the flag
+            auto f = [this, i, flag/* a copy of the shared ptr to the flag */]() {
+                std::atomic<bool> & _flag = *flag;
+                std::function<void(int id)> * _f;
+                bool isPop = this->q.pop(_f);
+                while (true) {
+                    while (isPop) {  // if there is anything in the queue
+                        std::unique_ptr<std::function<void(int id)>> func(_f);  // at return, delete the function even if an exception occurred
+                        (*_f)(i);
+
+                        if (_flag)
+                            return;  // the thread is wanted to stop, return even if the queue is not empty yet
+                        else
+                            isPop = this->q.pop(_f);
+                    }
+
+                    // the queue is empty here, wait for the next command
+                    std::unique_lock<std::mutex> lock(this->mutex);
+                    ++this->nWaiting;
+                    this->cv.wait(lock, [this, &_f, &isPop, &_flag](){ isPop = this->q.pop(_f); return isPop || this->isDone || _flag; });
+                    --this->nWaiting;
+
+                    if (!isPop)
+                        return;  // if the queue is empty and this->isDone == true or *flag then return
+                }
+            };
+            this->threads[i].reset(new std::thread(f));  // compiler may not support std::make_unique()
+        }
+
+        void init() { this->nWaiting = 0; this->isStop = false; this->isDone = false; }
+
+        std::vector<std::unique_ptr<std::thread>> threads;
+        std::vector<std::shared_ptr<std::atomic<bool>>> flags;
+        mutable boost::lockfree::queue<std::function<void(int id)> *> q;
+        std::atomic<bool> isDone;
+        std::atomic<bool> isStop;
+        std::atomic<int> nWaiting;  // how many threads are waiting
+
+        std::mutex mutex;
+        std::condition_variable cv;
+    };
+
+}
+
+#endif // __ctpl_thread_pool_H__
+

--- a/brickpi3/src/ext/ctpl_stl.h
+++ b/brickpi3/src/ext/ctpl_stl.h
@@ -1,0 +1,251 @@
+/*********************************************************
+*
+*  Copyright (C) 2014 by Vitaliy Vitsentiy
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*********************************************************/
+
+
+#ifndef __ctpl_stl_thread_pool_H__
+#define __ctpl_stl_thread_pool_H__
+
+#include <functional>
+#include <thread>
+#include <atomic>
+#include <vector>
+#include <memory>
+#include <exception>
+#include <future>
+#include <mutex>
+#include <queue>
+
+
+
+// thread pool to run user's functors with signature
+//      ret func(int id, other_params)
+// where id is the index of the thread that runs the functor
+// ret is some return type
+
+
+namespace ctpl {
+
+    namespace detail {
+        template <typename T>
+        class Queue {
+        public:
+            bool push(T const & value) {
+                std::unique_lock<std::mutex> lock(this->mutex);
+                this->q.push(value);
+                return true;
+            }
+            // deletes the retrieved element, do not use for non integral types
+            bool pop(T & v) {
+                std::unique_lock<std::mutex> lock(this->mutex);
+                if (this->q.empty())
+                    return false;
+                v = this->q.front();
+                this->q.pop();
+                return true;
+            }
+            bool empty() {
+                std::unique_lock<std::mutex> lock(this->mutex);
+                return this->q.empty();
+            }
+        private:
+            std::queue<T> q;
+            std::mutex mutex;
+        };
+    }
+
+    class thread_pool {
+
+    public:
+
+        thread_pool() { this->init(); }
+        thread_pool(int nThreads) { this->init(); this->resize(nThreads); }
+
+        // the destructor waits for all the functions in the queue to be finished
+        ~thread_pool() {
+            this->stop(true);
+        }
+
+        // get the number of running threads in the pool
+        int size() { return static_cast<int>(this->threads.size()); }
+
+        // number of idle threads
+        int n_idle() { return this->nWaiting; }
+        std::thread & get_thread(int i) { return *this->threads[i]; }
+
+        // change the number of threads in the pool
+        // should be called from one thread, otherwise be careful to not interleave, also with this->stop()
+        // nThreads must be >= 0
+        void resize(int nThreads) {
+            if (!this->isStop && !this->isDone) {
+                int oldNThreads = static_cast<int>(this->threads.size());
+                if (oldNThreads <= nThreads) {  // if the number of threads is increased
+                    this->threads.resize(nThreads);
+                    this->flags.resize(nThreads);
+
+                    for (int i = oldNThreads; i < nThreads; ++i) {
+                        this->flags[i] = std::make_shared<std::atomic<bool>>(false);
+                        this->set_thread(i);
+                    }
+                }
+                else {  // the number of threads is decreased
+                    for (int i = oldNThreads - 1; i >= nThreads; --i) {
+                        *this->flags[i] = true;  // this thread will finish
+                        this->threads[i]->detach();
+                    }
+                    {
+                        // stop the detached threads that were waiting
+                        std::unique_lock<std::mutex> lock(this->mutex);
+                        this->cv.notify_all();
+                    }
+                    this->threads.resize(nThreads);  // safe to delete because the threads are detached
+                    this->flags.resize(nThreads);  // safe to delete because the threads have copies of shared_ptr of the flags, not originals
+                }
+            }
+        }
+
+        // empty the queue
+        void clear_queue() {
+            std::function<void(int id)> * _f;
+            while (this->q.pop(_f))
+                delete _f; // empty the queue
+        }
+
+        // pops a functional wrapper to the original function
+        std::function<void(int)> pop() {
+            std::function<void(int id)> * _f = nullptr;
+            this->q.pop(_f);
+            std::unique_ptr<std::function<void(int id)>> func(_f); // at return, delete the function even if an exception occurred
+            std::function<void(int)> f;
+            if (_f)
+                f = *_f;
+            return f;
+        }
+
+        // wait for all computing threads to finish and stop all threads
+        // may be called asynchronously to not pause the calling thread while waiting
+        // if isWait == true, all the functions in the queue are run, otherwise the queue is cleared without running the functions
+        void stop(bool isWait = false) {
+            if (!isWait) {
+                if (this->isStop)
+                    return;
+                this->isStop = true;
+                for (int i = 0, n = this->size(); i < n; ++i) {
+                    *this->flags[i] = true;  // command the threads to stop
+                }
+                this->clear_queue();  // empty the queue
+            }
+            else {
+                if (this->isDone || this->isStop)
+                    return;
+                this->isDone = true;  // give the waiting threads a command to finish
+            }
+            {
+                std::unique_lock<std::mutex> lock(this->mutex);
+                this->cv.notify_all();  // stop all waiting threads
+            }
+            for (int i = 0; i < static_cast<int>(this->threads.size()); ++i) {  // wait for the computing threads to finish
+                    if (this->threads[i]->joinable())
+                        this->threads[i]->join();
+            }
+            // if there were no threads in the pool but some functors in the queue, the functors are not deleted by the threads
+            // therefore delete them here
+            this->clear_queue();
+            this->threads.clear();
+            this->flags.clear();
+        }
+
+        template<typename F, typename... Rest>
+        auto push(F && f, Rest&&... rest) ->std::future<decltype(f(0, rest...))> {
+            auto pck = std::make_shared<std::packaged_task<decltype(f(0, rest...))(int)>>(
+                std::bind(std::forward<F>(f), std::placeholders::_1, std::forward<Rest>(rest)...)
+                );
+            auto _f = new std::function<void(int id)>([pck](int id) {
+                (*pck)(id);
+            });
+            this->q.push(_f);
+            std::unique_lock<std::mutex> lock(this->mutex);
+            this->cv.notify_one();
+            return pck->get_future();
+        }
+
+        // run the user's function that excepts argument int - id of the running thread. returned value is templatized
+        // operator returns std::future, where the user can get the result and rethrow the catched exceptins
+        template<typename F>
+        auto push(F && f) ->std::future<decltype(f(0))> {
+            auto pck = std::make_shared<std::packaged_task<decltype(f(0))(int)>>(std::forward<F>(f));
+            auto _f = new std::function<void(int id)>([pck](int id) {
+                (*pck)(id);
+            });
+            this->q.push(_f);
+            std::unique_lock<std::mutex> lock(this->mutex);
+            this->cv.notify_one();
+            return pck->get_future();
+        }
+
+
+    private:
+
+        // deleted
+        thread_pool(const thread_pool &);// = delete;
+        thread_pool(thread_pool &&);// = delete;
+        thread_pool & operator=(const thread_pool &);// = delete;
+        thread_pool & operator=(thread_pool &&);// = delete;
+
+        void set_thread(int i) {
+            std::shared_ptr<std::atomic<bool>> flag(this->flags[i]); // a copy of the shared ptr to the flag
+            auto f = [this, i, flag/* a copy of the shared ptr to the flag */]() {
+                std::atomic<bool> & _flag = *flag;
+                std::function<void(int id)> * _f;
+                bool isPop = this->q.pop(_f);
+                while (true) {
+                    while (isPop) {  // if there is anything in the queue
+                        std::unique_ptr<std::function<void(int id)>> func(_f); // at return, delete the function even if an exception occurred
+                        (*_f)(i);
+                        if (_flag)
+                            return;  // the thread is wanted to stop, return even if the queue is not empty yet
+                        else
+                            isPop = this->q.pop(_f);
+                    }
+                    // the queue is empty here, wait for the next command
+                    std::unique_lock<std::mutex> lock(this->mutex);
+                    ++this->nWaiting;
+                    this->cv.wait(lock, [this, &_f, &isPop, &_flag](){ isPop = this->q.pop(_f); return isPop || this->isDone || _flag; });
+                    --this->nWaiting;
+                    if (!isPop)
+                        return;  // if the queue is empty and this->isDone == true or *flag then return
+                }
+            };
+            this->threads[i].reset(new std::thread(f)); // compiler may not support std::make_unique()
+        }
+
+        void init() { this->nWaiting = 0; this->isStop = false; this->isDone = false; }
+
+        std::vector<std::unique_ptr<std::thread>> threads;
+        std::vector<std::shared_ptr<std::atomic<bool>>> flags;
+        detail::Queue<std::function<void(int id)> *> q;
+        std::atomic<bool> isDone;
+        std::atomic<bool> isStop;
+        std::atomic<int> nWaiting;  // how many threads are waiting
+
+        std::mutex mutex;
+        std::condition_variable cv;
+    };
+
+}
+
+#endif // __ctpl_stl_thread_pool_H__

--- a/brickpi3_msgs/CMakeLists.txt
+++ b/brickpi3_msgs/CMakeLists.txt
@@ -1,0 +1,209 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(brickpi3_msgs)
+
+## Compile as C++11, supported in ROS Kinetic and newer
+# add_compile_options(-std=c++11)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS
+  std_msgs
+  geometry_msgs
+  message_generation
+)
+
+## System dependencies are found with CMake's conventions
+# find_package(Boost REQUIRED COMPONENTS system)
+
+
+## Uncomment this if the package has a setup.py. This macro ensures
+## modules and global scripts declared therein get installed
+## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
+# catkin_python_setup()
+
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+## To declare and build messages, services or actions from within this
+## package, follow these steps:
+## * Let MSG_DEP_SET be the set of packages whose message types you use in
+##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
+## * In the file package.xml:
+##   * add a build_depend tag for "message_generation"
+##   * add a build_depend and a exec_depend tag for each package in MSG_DEP_SET
+##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
+##     but can be declared for certainty nonetheless:
+##     * add a exec_depend tag for "message_runtime"
+## * In this file (CMakeLists.txt):
+##   * add "message_generation" and every package in MSG_DEP_SET to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * add "message_runtime" and every package in MSG_DEP_SET to
+##     catkin_package(CATKIN_DEPENDS ...)
+##   * uncomment the add_*_files sections below as needed
+##     and list every .msg/.srv/.action file to be processed
+##   * uncomment the generate_messages entry below
+##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
+
+## Generate messages in the 'msg' folder
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
+add_message_files(FILES
+  Accelerometer.msg
+  Color.msg
+  Contact.msg
+  Gyro.msg
+  JointCommand.msg
+  Light.msg
+  Range.msg
+)
+
+## Generate services in the 'srv' folder
+# add_service_files(
+#   FILES
+#   Service1.srv
+#   Service2.srv
+# )
+
+## Generate actions in the 'action' folder
+# add_action_files(
+#   FILES
+#   Action1.action
+#   Action2.action
+# )
+
+## Generate added messages and services with any dependencies listed here
+generate_messages(DEPENDENCIES
+  std_msgs
+  geometry_msgs
+  brickpi3_msgs
+)
+
+################################################
+## Declare ROS dynamic reconfigure parameters ##
+################################################
+
+## To declare and build dynamic reconfigure parameters within this
+## package, follow these steps:
+## * In the file package.xml:
+##   * add a build_depend and a exec_depend tag for "dynamic_reconfigure"
+## * In this file (CMakeLists.txt):
+##   * add "dynamic_reconfigure" to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * uncomment the "generate_dynamic_reconfigure_options" section below
+##     and list every .cfg file to be processed
+
+## Generate dynamic reconfigure parameters in the 'cfg' folder
+# generate_dynamic_reconfigure_options(
+#   cfg/DynReconf1.cfg
+#   cfg/DynReconf2.cfg
+# )
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if your package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES brickpi3
+  CATKIN_DEPENDS std_msgs geometry_msgs message_runtime
+#  DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+#include_directories(
+# include
+#  ${catkin_INCLUDE_DIRS}
+#)
+
+## Declare a C++ library
+# add_library(${PROJECT_NAME}
+#   src/${PROJECT_NAME}/brikpi3_ros.cpp
+# )
+
+## Add cmake target dependencies of the library
+## as an example, code may need to be generated before libraries
+## either from message generation or dynamic reconfigure
+# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Declare a C++ executable
+## With catkin_make all packages are built within a single CMake context
+## The recommended prefix ensures that target names across packages don't collide
+# add_executable(${PROJECT_NAME}_node src/brikpi3_ros_node.cpp)
+
+## Rename C++ executable without prefix
+## The above recommended prefix causes long target names, the following renames the
+## target back to the shorter version for ease of user use
+## e.g. "rosrun someones_pkg node" instead of "rosrun someones_pkg someones_pkg_node"
+# set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX "")
+
+## Add cmake target dependencies of the executable
+## same as for the library above
+# add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Specify libraries to link a library or executable target against
+# target_link_libraries(${PROJECT_NAME}_node
+#   ${catkin_LIBRARIES}
+# )
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+# install(PROGRAMS
+#   scripts/my_python_script
+#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark executables and/or libraries for installation
+# install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_node
+#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark cpp header files for installation
+# install(DIRECTORY include/${PROJECT_NAME}/
+#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+#   FILES_MATCHING PATTERN "*.h"
+#   PATTERN ".svn" EXCLUDE
+# )
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+# install(FILES
+#   # myfile1
+#   # myfile2
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# )
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_brikpi3_ros.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)

--- a/brickpi3_msgs/CMakeLists.txt
+++ b/brickpi3_msgs/CMakeLists.txt
@@ -1,209 +1,33 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(brickpi3_msgs)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-# add_compile_options(-std=c++11)
-
-## Find catkin macros and libraries
-## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
-## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS
-  std_msgs
-  geometry_msgs
-  message_generation
+find_package(catkin REQUIRED
+  COMPONENTS
+    geometry_msgs
+    message_generation
+    std_msgs
 )
 
-## System dependencies are found with CMake's conventions
-# find_package(Boost REQUIRED COMPONENTS system)
-
-
-## Uncomment this if the package has a setup.py. This macro ensures
-## modules and global scripts declared therein get installed
-## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
-# catkin_python_setup()
-
-################################################
-## Declare ROS messages, services and actions ##
-################################################
-
-## To declare and build messages, services or actions from within this
-## package, follow these steps:
-## * Let MSG_DEP_SET be the set of packages whose message types you use in
-##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
-## * In the file package.xml:
-##   * add a build_depend tag for "message_generation"
-##   * add a build_depend and a exec_depend tag for each package in MSG_DEP_SET
-##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
-##     but can be declared for certainty nonetheless:
-##     * add a exec_depend tag for "message_runtime"
-## * In this file (CMakeLists.txt):
-##   * add "message_generation" and every package in MSG_DEP_SET to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * add "message_runtime" and every package in MSG_DEP_SET to
-##     catkin_package(CATKIN_DEPENDS ...)
-##   * uncomment the add_*_files sections below as needed
-##     and list every .msg/.srv/.action file to be processed
-##   * uncomment the generate_messages entry below
-##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
-
-## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
-add_message_files(FILES
-  Accelerometer.msg
-  Color.msg
-  Contact.msg
-  Gyro.msg
-  JointCommand.msg
-  Light.msg
-  Range.msg
+add_message_files(
+  FILES
+    Accelerometer.msg
+    Color.msg
+    Contact.msg
+    Gyro.msg
+    JointCommand.msg
+    Light.msg
+    Range.msg
 )
 
-## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
-
-## Generate actions in the 'action' folder
-# add_action_files(
-#   FILES
-#   Action1.action
-#   Action2.action
-# )
-
-## Generate added messages and services with any dependencies listed here
-generate_messages(DEPENDENCIES
-  std_msgs
-  geometry_msgs
-  brickpi3_msgs
+generate_messages(
+  DEPENDENCIES
+    geometry_msgs
+    std_msgs
 )
 
-################################################
-## Declare ROS dynamic reconfigure parameters ##
-################################################
-
-## To declare and build dynamic reconfigure parameters within this
-## package, follow these steps:
-## * In the file package.xml:
-##   * add a build_depend and a exec_depend tag for "dynamic_reconfigure"
-## * In this file (CMakeLists.txt):
-##   * add "dynamic_reconfigure" to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * uncomment the "generate_dynamic_reconfigure_options" section below
-##     and list every .cfg file to be processed
-
-## Generate dynamic reconfigure parameters in the 'cfg' folder
-# generate_dynamic_reconfigure_options(
-#   cfg/DynReconf1.cfg
-#   cfg/DynReconf2.cfg
-# )
-
-###################################
-## catkin specific configuration ##
-###################################
-## The catkin_package macro generates cmake config files for your package
-## Declare things to be passed to dependent projects
-## INCLUDE_DIRS: uncomment this if your package contains header files
-## LIBRARIES: libraries you create in this project that dependent projects also need
-## CATKIN_DEPENDS: catkin_packages dependent projects also need
-## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-#  INCLUDE_DIRS include
-#  LIBRARIES brickpi3
-  CATKIN_DEPENDS std_msgs geometry_msgs message_runtime
-#  DEPENDS system_lib
+  CATKIN_DEPENDS
+    geometry_msgs
+    message_runtime
+    std_msgs
 )
-
-###########
-## Build ##
-###########
-
-## Specify additional locations of header files
-## Your package locations should be listed before other locations
-#include_directories(
-# include
-#  ${catkin_INCLUDE_DIRS}
-#)
-
-## Declare a C++ library
-# add_library(${PROJECT_NAME}
-#   src/${PROJECT_NAME}/brikpi3_ros.cpp
-# )
-
-## Add cmake target dependencies of the library
-## as an example, code may need to be generated before libraries
-## either from message generation or dynamic reconfigure
-# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-## Declare a C++ executable
-## With catkin_make all packages are built within a single CMake context
-## The recommended prefix ensures that target names across packages don't collide
-# add_executable(${PROJECT_NAME}_node src/brikpi3_ros_node.cpp)
-
-## Rename C++ executable without prefix
-## The above recommended prefix causes long target names, the following renames the
-## target back to the shorter version for ease of user use
-## e.g. "rosrun someones_pkg node" instead of "rosrun someones_pkg someones_pkg_node"
-# set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX "")
-
-## Add cmake target dependencies of the executable
-## same as for the library above
-# add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-## Specify libraries to link a library or executable target against
-# target_link_libraries(${PROJECT_NAME}_node
-#   ${catkin_LIBRARIES}
-# )
-
-#############
-## Install ##
-#############
-
-# all install targets should use catkin DESTINATION variables
-# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
-
-## Mark executable scripts (Python etc.) for installation
-## in contrast to setup.py, you can choose the destination
-# install(PROGRAMS
-#   scripts/my_python_script
-#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark executables and/or libraries for installation
-# install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_node
-#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark cpp header files for installation
-# install(DIRECTORY include/${PROJECT_NAME}/
-#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-#   FILES_MATCHING PATTERN "*.h"
-#   PATTERN ".svn" EXCLUDE
-# )
-
-## Mark other files for installation (e.g. launch and bag files, etc.)
-# install(FILES
-#   # myfile1
-#   # myfile2
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
-
-#############
-## Testing ##
-#############
-
-## Add gtest based cpp test target and link libraries
-# catkin_add_gtest(${PROJECT_NAME}-test test/test_brikpi3_ros.cpp)
-# if(TARGET ${PROJECT_NAME}-test)
-#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
-# endif()
-
-## Add folders to be run by python nosetests
-# catkin_add_nosetests(test)

--- a/brickpi3_msgs/msg/Accelerometer.msg
+++ b/brickpi3_msgs/msg/Accelerometer.msg
@@ -1,0 +1,3 @@
+Header header
+geometry_msgs/Vector3 linear_acceleration
+float64[9] linear_acceleration_covariance

--- a/brickpi3_msgs/msg/Color.msg
+++ b/brickpi3_msgs/msg/Color.msg
@@ -1,0 +1,5 @@
+Header header
+float64 intensity
+float64 r
+float64 g
+float64 b

--- a/brickpi3_msgs/msg/Contact.msg
+++ b/brickpi3_msgs/msg/Contact.msg
@@ -1,0 +1,2 @@
+Header header
+bool contact

--- a/brickpi3_msgs/msg/Gyro.msg
+++ b/brickpi3_msgs/msg/Gyro.msg
@@ -1,0 +1,4 @@
+Header header
+geometry_msgs/Vector3 calibration_offset
+geometry_msgs/Vector3 angular_velocity
+float64[9] angular_velocity_covariance

--- a/brickpi3_msgs/msg/JointCommand.msg
+++ b/brickpi3_msgs/msg/JointCommand.msg
@@ -1,0 +1,2 @@
+string name
+float64 effort

--- a/brickpi3_msgs/msg/Light.msg
+++ b/brickpi3_msgs/msg/Light.msg
@@ -1,0 +1,2 @@
+Header header
+float64 intensity

--- a/brickpi3_msgs/msg/Range.msg
+++ b/brickpi3_msgs/msg/Range.msg
@@ -1,0 +1,5 @@
+Header header
+float64 range
+float64 range_min
+float64 range_max
+float64 spread_angle

--- a/brickpi3_msgs/package.xml
+++ b/brickpi3_msgs/package.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>brickpi3_msgs</name>
+  <version>0.1.0</version>
+  <description>The RxROS brickpi3 message package</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="wasowski@itu.dk">Andrzej Wasowski</maintainer>
+  <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn</maintainer>
+  <maintainer email="henrik7264@outlook.com">Henrik Larsen</maintainer>
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>BSD</license>
+
+  <!-- Url tags are optional, but multiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://wiki.ros.org/brickpi3_ros</url> -->
+
+
+  <!-- Author tags are optional, multiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintainers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+
+  <!-- The *depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
+  <!--   <depend>roscpp</depend> -->
+  <!--   Note that this is equivalent to the following: -->
+  <!--   <build_depend>roscpp</build_depend> -->
+  <!--   <exec_depend>roscpp</exec_depend> -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use build_export_depend for packages you need in order to build against this package: -->
+  <!--   <build_export_depend>message_generation</build_export_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use exec_depend for packages you need at runtime: -->
+  <!--   <exec_depend>message_runtime</exec_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <!-- Use doc_depend for packages you need only for building documentation: -->
+  <!--   <doc_depend>doxygen</doc_depend> -->
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>message_generation</build_depend>
+  <build_export_depend>roscpp</build_export_depend>
+  <build_export_depend>rospy</build_export_depend>
+  <build_export_depend>std_msgs</build_export_depend>
+  <build_export_depend>geometry_msgs</build_export_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>message_runtime</exec_depend>
+
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/brickpi3_msgs/package.xml
+++ b/brickpi3_msgs/package.xml
@@ -3,69 +3,17 @@
   <name>brickpi3_msgs</name>
   <version>0.1.0</version>
   <description>The RxROS brickpi3 message package</description>
-
-  <!-- One maintainer tag required, multiple allowed, one person per tag -->
-  <!-- Example:  -->
-  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="wasowski@itu.dk">Andrzej Wasowski</maintainer>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn</maintainer>
   <maintainer email="henrik7264@outlook.com">Henrik Larsen</maintainer>
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
   <license>BSD</license>
 
-  <!-- Url tags are optional, but multiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/brickpi3_ros</url> -->
-
-
-  <!-- Author tags are optional, multiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintainers, but could be -->
-  <!-- Example: -->
-  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
-
-
-  <!-- The *depend tags are used to specify dependencies -->
-  <!-- Dependencies can be catkin packages or system dependencies -->
-  <!-- Examples: -->
-  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
-  <!--   <depend>roscpp</depend> -->
-  <!--   Note that this is equivalent to the following: -->
-  <!--   <build_depend>roscpp</build_depend> -->
-  <!--   <exec_depend>roscpp</exec_depend> -->
-  <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
-  <!-- Use build_export_depend for packages you need in order to build against this package: -->
-  <!--   <build_export_depend>message_generation</build_export_depend> -->
-  <!-- Use buildtool_depend for build tool packages: -->
-  <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use exec_depend for packages you need at runtime: -->
-  <!--   <exec_depend>message_runtime</exec_depend> -->
-  <!-- Use test_depend for packages you need only for testing: -->
-  <!--   <test_depend>gtest</test_depend> -->
-  <!-- Use doc_depend for packages you need only for building documentation: -->
-  <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>rospy</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>geometry_msgs</build_depend>
+
+  <depend>std_msgs</depend>
+  <depend>geometry_msgs</depend>
+
   <build_depend>message_generation</build_depend>
-  <build_export_depend>roscpp</build_export_depend>
-  <build_export_depend>rospy</build_export_depend>
-  <build_export_depend>std_msgs</build_export_depend>
-  <build_export_depend>geometry_msgs</build_export_depend>
-  <exec_depend>std_msgs</exec_depend>
-  <exec_depend>geometry_msgs</exec_depend>
+  <build_export_depend>message_runtime</build_export_depend>
   <exec_depend>message_runtime</exec_depend>
-
-
-  <!-- The export tag contains other, unspecified, tags -->
-  <export>
-    <!-- Other tools can request additional information be placed here -->
-
-  </export>
 </package>

--- a/rxros_examples.rosinstall
+++ b/rxros_examples.rosinstall
@@ -1,0 +1,9 @@
+- git:
+    uri: https://github.com/rosin-project/rxros.git
+    local-name: rxros
+- git:
+    uri: https://github.com/rosin-project/rxcpp_vendor.git
+    local-name: rxcpp_vendor
+- git:
+    uri: https://github.com/rosin-project/rxros_examples.git
+    local-name: rxros_examples

--- a/teleop/CMakeLists.txt
+++ b/teleop/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(teleop)
+
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  rxros
+  std_msgs
+  teleop_msgs
+)
+
+catkin_package(
+  CATKIN_DEPENDS
+    roscpp
+    rxros
+    std_msgs
+    teleop_msgs
+)
+
+include_directories(${catkin_INCLUDE_DIRS})
+
+
+add_executable(joystick_publisher       src/JoystickPublisher.cpp)
+add_executable(joystick_publisher_rxros src/JoystickPublisher_rx.cpp)
+add_executable(keyboard_publisher       src/KeyboardPublisher.cpp)
+add_executable(keyboard_publisher_rxros src/KeyboardPublisher_rx.cpp)
+add_executable(velocity_publisher       src/VelocityPublisher.cpp)
+add_executable(velocity_publisher_rxros src/VelocityPublisher_rx.cpp)
+
+add_dependencies(joystick_publisher       ${catkin_EXPORTED_TARGETS})
+add_dependencies(joystick_publisher_rxros ${catkin_EXPORTED_TARGETS})
+add_dependencies(keyboard_publisher       ${catkin_EXPORTED_TARGETS})
+add_dependencies(keyboard_publisher_rxros ${catkin_EXPORTED_TARGETS})
+add_dependencies(velocity_publisher       ${catkin_EXPORTED_TARGETS})
+add_dependencies(velocity_publisher_rxros ${catkin_EXPORTED_TARGETS})
+
+target_link_libraries(joystick_publisher       ${catkin_LIBRARIES})
+target_link_libraries(joystick_publisher_rxros ${catkin_LIBRARIES})
+target_link_libraries(keyboard_publisher       ${catkin_LIBRARIES})
+target_link_libraries(keyboard_publisher_rxros ${catkin_LIBRARIES})
+target_link_libraries(velocity_publisher       ${catkin_LIBRARIES})
+target_link_libraries(velocity_publisher_rxros ${catkin_LIBRARIES})

--- a/teleop/CMakeLists.txt
+++ b/teleop/CMakeLists.txt
@@ -42,3 +42,15 @@ target_link_libraries(keyboard_publisher       ${catkin_LIBRARIES})
 target_link_libraries(keyboard_publisher_rxros ${catkin_LIBRARIES})
 target_link_libraries(velocity_publisher       ${catkin_LIBRARIES})
 target_link_libraries(velocity_publisher_rxros ${catkin_LIBRARIES})
+
+install(
+  TARGETS
+    joystick_publisher
+    joystick_publisher_rxros
+    keyboard_publisher
+    keyboard_publisher_rxros
+    velocity_publisher
+    velocity_publisher_rxros
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})

--- a/teleop/CMakeLists.txt
+++ b/teleop/CMakeLists.txt
@@ -7,7 +7,6 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 find_package(catkin REQUIRED COMPONENTS
-  roscpp
   rxros
   std_msgs
   teleop_msgs
@@ -15,7 +14,6 @@ find_package(catkin REQUIRED COMPONENTS
 
 catkin_package(
   CATKIN_DEPENDS
-    roscpp
     rxros
     std_msgs
     teleop_msgs

--- a/teleop/CMakeLists.txt
+++ b/teleop/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(teleop)
 
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   rxros

--- a/teleop/package.xml
+++ b/teleop/package.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>teleop</name>
+  <version>0.1.0</version>
+  <description>The RxROS teleop package</description>
+
+  <maintainer email="wasowski@itu.dk">Andrzej Wasowski</maintainer>
+  <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn</maintainer>
+  <maintainer email="henrik7264@outlook.com">Henrik Larsen</maintainer>
+
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>roscpp</build_depend>
+  <build_depend>rxros</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>teleop_msgs</build_depend>
+
+  <build_export_depend>roscpp</build_export_depend>
+  <build_export_depend>rxros</build_export_depend>
+  <build_export_depend>std_msgs</build_export_depend>
+  <build_export_depend>teleop_msgs</build_export_depend>
+
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>rxros</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>teleop_msgs</exec_depend>
+</package>

--- a/teleop/package.xml
+++ b/teleop/package.xml
@@ -12,15 +12,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>rxros</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>teleop_msgs</build_depend>
-
-  <build_export_depend>rxros</build_export_depend>
-  <build_export_depend>std_msgs</build_export_depend>
-  <build_export_depend>teleop_msgs</build_export_depend>
-
-  <exec_depend>rxros</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
-  <exec_depend>teleop_msgs</exec_depend>
+  <depend>rxros</depend>
+  <depend>std_msgs</depend>
+  <depend>teleop_msgs</depend>
 </package>

--- a/teleop/package.xml
+++ b/teleop/package.xml
@@ -12,17 +12,14 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>roscpp</build_depend>
   <build_depend>rxros</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>teleop_msgs</build_depend>
 
-  <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>rxros</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
   <build_export_depend>teleop_msgs</build_export_depend>
 
-  <exec_depend>roscpp</exec_depend>
   <exec_depend>rxros</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>teleop_msgs</exec_depend>

--- a/teleop/src/JoystickPublisher.cpp
+++ b/teleop/src/JoystickPublisher.cpp
@@ -1,0 +1,125 @@
+/*
+Copyright (c) 2019, ROSIN-project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <fcntl.h>
+#include <string>
+#include <ros/ros.h>
+#include <ros/console.h>
+#include <teleop_msgs/Joystick.h>
+#include "JoystickPublisher.h"
+
+#define JS_EVENT_BUTTON 0x01    /* button pressed/released */
+#define JS_EVENT_AXIS   0x02    /* joystick moved */
+
+struct joystick_event {
+    unsigned int time;      /* event timestamp in milliseconds */
+    short value;            /* value */
+    unsigned char type;     /* event type */
+    unsigned char number;   /* axis/button number */
+};
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "joystick_publisher"); // Name of this Node.
+    ros::NodeHandle nodeHandle;
+    ros::Publisher publisher = nodeHandle.advertise<teleop_msgs::Joystick>("/joystick", 10); // Publisher Topic /joystick
+
+    // Read parameter device
+    std::string joystickDevice;
+    nodeHandle.param<std::string>("/joystick_publisher/device", joystickDevice, "/dev/input/js0");
+
+    int fd = open(joystickDevice.c_str(), O_RDONLY);
+    if( fd < 0 ) {
+        printf("Cannot open joystick device.\n");
+        exit(1);
+    }
+
+    struct joystick_event joystickEvent;
+    while (ros::ok()) {
+        read(fd, &joystickEvent, sizeof(joystickEvent));
+        if (joystickEvent.type == JS_EVENT_BUTTON || joystickEvent.type == JS_EVENT_AXIS) {
+            ros::Time rosTime(joystickEvent.time, 0);
+            teleop_msgs::Joystick joystick;
+            joystick.time = rosTime;
+
+            unsigned char type = joystickEvent.type;
+            unsigned char number = joystickEvent.number;
+            short value = joystickEvent.value;
+            joystick.event = JS_EVENT_NEUTRAL;
+            if (type == JS_EVENT_BUTTON) {
+                if (number == 0 && value == 0) {
+                    joystick.event = JS_EVENT_BUTTON0_UP;
+                }
+                else if (number == 0 && value == 1) {
+                    joystick.event = JS_EVENT_BUTTON0_DOWN;
+                }
+                else if (number == 1 && value == 0) {
+                    joystick.event = JS_EVENT_BUTTON1_UP;
+                }
+                else if (number == 1 && value == 1) {
+                    joystick.event = JS_EVENT_BUTTON1_DOWN;
+                }
+                else if (number == 2 && value == 0) {
+                    joystick.event = JS_EVENT_BUTTON2_UP;
+                }
+                else if (number == 2 && value == 1) {
+                    joystick.event = JS_EVENT_BUTTON2_DOWN;
+                }
+                else if (number == 3 && value == 0) {
+                    joystick.event = JS_EVENT_BUTTON3_UP;
+                }
+                else if (number == 3 && value == 1) {
+                    joystick.event = JS_EVENT_BUTTON3_DOWN;
+                }
+            }
+            else if (type == JS_EVENT_AXIS) {
+                if (number==0 && value == 32767)
+                {
+                    joystick.event = JS_EVENT_AXIS_RIGHT;
+                }
+                else if (number==0 && value==-32767)
+                {
+                    joystick.event = JS_EVENT_AXIS_LEFT;
+                }
+                else if (number==1 && value==32767)
+                {
+                    joystick.event = JS_EVENT_AXIS_DOWN;
+                }
+                else if (number==1 && value==-32767) {
+                    joystick.event = JS_EVENT_AXIS_UP;
+                }
+            }
+
+            if (joystick.event != JS_EVENT_NEUTRAL) {
+                publisher.publish(joystick);
+            }
+        }
+    }
+}

--- a/teleop/src/JoystickPublisher.h
+++ b/teleop/src/JoystickPublisher.h
@@ -1,0 +1,51 @@
+/*
+Copyright (c) 2019, ROSIN-project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef TELEOP_JOYSTICKPUBLISHER_H
+#define TELEOP_JOYSTICKPUBLISHER_H
+
+enum JoystickEvents
+{
+    JS_EVENT_NEUTRAL = 0, // to avoid conflicts with KeyboardEvents
+    JS_EVENT_BUTTON0_DOWN,
+    JS_EVENT_BUTTON0_UP,
+    JS_EVENT_BUTTON1_DOWN,
+    JS_EVENT_BUTTON1_UP,
+    JS_EVENT_BUTTON2_DOWN,
+    JS_EVENT_BUTTON2_UP,
+    JS_EVENT_BUTTON3_DOWN,
+    JS_EVENT_BUTTON3_UP,
+    JS_EVENT_AXIS_UP,
+    JS_EVENT_AXIS_LEFT,
+    JS_EVENT_AXIS_RIGHT,
+    JS_EVENT_AXIS_DOWN
+};
+
+#endif //TELEOP_JOYSTICKPUBLISHER_H

--- a/teleop/src/JoystickPublisher_rx.cpp
+++ b/teleop/src/JoystickPublisher_rx.cpp
@@ -1,0 +1,99 @@
+/*
+Copyright (c) 2019, ROSIN-project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <rxros.h>
+#include <teleop_msgs/Joystick.h>
+#include "JoystickPublisher.h"
+using namespace rxcpp::operators;
+using namespace rxros::operators;
+
+
+#define JS_EVENT_BUTTON 0x01    /* button pressed/released */
+#define JS_EVENT_AXIS   0x02    /* joystick moved */
+
+struct joystick_event
+{
+    unsigned int time;      /* event timestamp in milliseconds */
+    short value;            /* value */
+    unsigned char type;     /* event type */
+    unsigned char number;   /* axis/button number */
+};
+
+int main(int argc, char** argv)
+{
+    rxros::init(argc, argv, "joystick_publisher"); // Name of this Node.
+
+    const auto joystickDevice = rxros::parameter::get("/joystick_publisher/device", "/dev/input/js0");
+    rxros::logging().info() << "Joystick device: " << joystickDevice;
+
+    auto joystickEvent2JoystickMsg = [=](const auto joystickEvent) {
+        auto makeJoystickMsg = [=] (auto event) {
+            teleop_msgs::Joystick joystickMsg;
+            joystickMsg.time = ros::Time(joystickEvent.time, 0);
+            joystickMsg.event = event;
+            return joystickMsg;};
+        if (joystickEvent.type == JS_EVENT_BUTTON) {
+            if (joystickEvent.number == 0 && joystickEvent.value == 0)
+                return makeJoystickMsg(JS_EVENT_BUTTON0_UP);
+            else if (joystickEvent.number == 0 && joystickEvent.value == 1)
+                return makeJoystickMsg(JS_EVENT_BUTTON0_DOWN);
+            else if (joystickEvent.number == 1 && joystickEvent.value == 0)
+                return makeJoystickMsg(JS_EVENT_BUTTON1_UP);
+            else if (joystickEvent.number == 1 && joystickEvent.value == 1)
+                return makeJoystickMsg(JS_EVENT_BUTTON1_DOWN);
+            else if (joystickEvent.number == 2 && joystickEvent.value == 0)
+                return makeJoystickMsg(JS_EVENT_BUTTON2_UP);
+            else if (joystickEvent.number == 2 && joystickEvent.value == 1)
+                return makeJoystickMsg(JS_EVENT_BUTTON2_DOWN);
+            else if (joystickEvent.number == 3 && joystickEvent.value == 0)
+                return makeJoystickMsg(JS_EVENT_BUTTON3_UP);
+            else if (joystickEvent.number == 3 && joystickEvent.value == 1)
+                return makeJoystickMsg(JS_EVENT_BUTTON3_DOWN);
+        }
+        else if (joystickEvent.type == JS_EVENT_AXIS) {
+            if (joystickEvent.number == 0 && joystickEvent.value == 32767)
+                return makeJoystickMsg(JS_EVENT_AXIS_RIGHT);
+            else if (joystickEvent.number == 0 && joystickEvent.value == -32767)
+                return makeJoystickMsg(JS_EVENT_AXIS_LEFT);
+            else if (joystickEvent.number == 1 && joystickEvent.value == 32767)
+                return makeJoystickMsg(JS_EVENT_AXIS_DOWN);
+            else if (joystickEvent.number == 1 && joystickEvent.value == -32767)
+                return makeJoystickMsg(JS_EVENT_AXIS_UP);
+        }
+        else
+            return makeJoystickMsg(JS_EVENT_NEUTRAL);};
+
+    rxros::observable::from_device<joystick_event>(joystickDevice)
+        | map(joystickEvent2JoystickMsg)
+        | publish_to_topic<teleop_msgs::Joystick>("/joystick");
+
+    rxros::logging().info() << "Spinning joystick_publisher ...";
+    rxros::spin();
+}

--- a/teleop/src/JoystickPublisher_rx.cpp
+++ b/teleop/src/JoystickPublisher_rx.cpp
@@ -28,7 +28,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <rxros.h>
+#include <rxros/rxros.h>
 #include <teleop_msgs/Joystick.h>
 #include "JoystickPublisher.h"
 using namespace rxcpp::operators;

--- a/teleop/src/KeyboardPublisher.cpp
+++ b/teleop/src/KeyboardPublisher.cpp
@@ -1,0 +1,120 @@
+/*
+Copyright (c) 2019, ROSIN-project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <linux/input.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <cstdlib>
+#include <ros/ros.h>
+#include <ros/console.h>
+#include <teleop_msgs/Keyboard.h>
+#include "KeyboardPublisher.h"
+
+int main(int argc, char** argv)
+{
+    // Initialize ROS
+    ros::init(argc, argv, "keyboard_publisher"); // Name of this Node.
+    ros::NodeHandle nodeHandle;
+    ros::Publisher pub = nodeHandle.advertise<teleop_msgs::Keyboard>("/keyboard", 10); // Publisher Topic /keyboard
+
+    // Read parameter device
+    std::string keyboardDevice;
+    nodeHandle.param<std::string>("/keyboard_publisher/device", keyboardDevice, "/dev/input/event3");
+//    nodeHandle.param<std::string>("/keyboard_publisher/device", keyboardDevice, "/dev/input/event1");
+
+    printf("keyboard device: %s\n", keyboardDevice.c_str());
+
+    // Open specified device. Needs to be in the group input to get access to the device!
+    int fd = open(keyboardDevice.c_str(), O_RDONLY | O_NONBLOCK);
+    if( fd < 0 ) {
+        printf("Cannot open keyboard device %s!\n", keyboardDevice.c_str());
+        exit(1);
+    }
+
+    fd_set readfds; // initialize file descriptor set.
+    FD_ZERO(&readfds);
+    FD_SET(fd, &readfds);
+    bool doLoop = true;
+    input_event keyboardEvent;
+    while (doLoop && ros::ok()) {
+        int rc = select(fd+1, &readfds, nullptr, nullptr, nullptr);  // wait for input on keyboard device
+        if (rc == -1 && errno == EINTR) {
+            close(fd);
+            doLoop = false;
+        }
+        else if (rc == -1 || rc == 0) {
+            printf("Failed to read keyboard. Exception: %d.\n", errno);
+            close(fd);
+            doLoop = false;
+        }
+        else {
+            if (FD_ISSET(fd, &readfds)) {
+                ssize_t sz = read(fd, &keyboardEvent, sizeof(keyboardEvent)); // read pressed key
+                if (sz == -1) {
+                    printf("Failed to read keyboard. Exception: %d.\n", errno);
+                    close(fd);
+                    doLoop = false;
+                }
+                else if (sz == sizeof(keyboardEvent)) {
+                    if ((keyboardEvent.type == EV_KEY) && (keyboardEvent.value != REP_DELAY)) {
+                        //printf("Key: T:%d, C:%d, V:%d\n", keyboardEvent.type, keyboardEvent.code, keyboardEvent.value);
+
+                        teleop_msgs::Keyboard keyboard;
+                        ros::Time rosTime(keyboardEvent.time.tv_sec, keyboardEvent.time.tv_usec);
+                        keyboard.time = rosTime;
+                        switch (keyboardEvent.code) {
+                            case KEY_UP:
+                                keyboard.event = KB_EVENT_UP;
+                                break;
+                            case KEY_LEFT:
+                                keyboard.event = KB_EVENT_LEFT;
+                                break;
+                            case KEY_RIGHT:
+                                keyboard.event = KB_EVENT_RIGHT;
+                                break;
+                            case KEY_DOWN:
+                                keyboard.event = KB_EVENT_DOWN;
+                                break;
+                            case KEY_SPACE:
+                                keyboard.event = KB_EVENT_SPACE;
+                                break;
+                            default:
+                                keyboard.event = KB_EVENT_NONE;
+                                break;
+                        }
+
+                        pub.publish(keyboard);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/teleop/src/KeyboardPublisher.h
+++ b/teleop/src/KeyboardPublisher.h
@@ -1,0 +1,44 @@
+/*
+Copyright (c) 2019, ROSIN-project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef TELEOP_KEYBOARDPUBLISHER_H
+#define TELEOP_KEYBOARDPUBLISHER_H
+
+enum KeyboardEvents
+{
+    KB_EVENT_NONE = 100, // to avoid conflicts with JoystickEvents
+    KB_EVENT_UP,
+    KB_EVENT_LEFT,
+    KB_EVENT_RIGHT,
+    KB_EVENT_DOWN,
+    KB_EVENT_SPACE
+};
+
+#endif //TELEOP_KEYBOARDPUBLISHER_H

--- a/teleop/src/KeyboardPublisher_rx.cpp
+++ b/teleop/src/KeyboardPublisher_rx.cpp
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2019, ROSIN-project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <rxros.h>
+#include <teleop_msgs/Keyboard.h>
+#include "KeyboardPublisher.h"
+using namespace rxcpp::operators;
+using namespace rxros::operators;
+
+
+int main(int argc, char** argv)
+{
+    rxros::init(argc, argv, "keyboard_publisher"); // Name of this Node.
+
+    const auto keyboardDevice = rxros::parameter::get("/keyboard_publisher/device", "/dev/input/event4"); // Use event4 for dell, event4 for nuc and event1 for others
+    rxros::logging().info() << "Keyboard device: " << keyboardDevice;
+
+    auto keyboardEvent2KeyboardMsg = [](const auto keyboardEvent) {
+        auto makeKeyboardMsg = [=] (auto event) {
+            teleop_msgs::Keyboard keyboardMsg;
+            keyboardMsg.time = ros::Time(keyboardEvent.time.tv_sec, keyboardEvent.time.tv_usec);
+            keyboardMsg.event = event;
+            return keyboardMsg;};
+        if ((keyboardEvent.type == EV_KEY) && (keyboardEvent.value != REP_DELAY)) {
+            if (keyboardEvent.code==KEY_UP)
+                return makeKeyboardMsg(KB_EVENT_UP);
+            else if (keyboardEvent.code==KEY_LEFT)
+                return makeKeyboardMsg(KB_EVENT_LEFT);
+            else if (keyboardEvent.code==KEY_RIGHT)
+                return makeKeyboardMsg(KB_EVENT_RIGHT);
+            else if (keyboardEvent.code==KEY_DOWN)
+                return makeKeyboardMsg(KB_EVENT_DOWN);
+            else if (keyboardEvent.code==KEY_SPACE)
+                return makeKeyboardMsg(KB_EVENT_SPACE);
+        }
+        return makeKeyboardMsg(KB_EVENT_NONE);};
+
+    rxros::observable::from_device<input_event>(keyboardDevice)
+        | map(keyboardEvent2KeyboardMsg)
+        | publish_to_topic<teleop_msgs::Keyboard>("/keyboard");
+
+    rxros::logging().info() << "Spinning keyboard_publisher...";
+    rxros::spin();
+}

--- a/teleop/src/KeyboardPublisher_rx.cpp
+++ b/teleop/src/KeyboardPublisher_rx.cpp
@@ -28,7 +28,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <rxros.h>
+#include <rxros/rxros.h>
 #include <teleop_msgs/Keyboard.h>
 #include "KeyboardPublisher.h"
 using namespace rxcpp::operators;

--- a/teleop/src/VelocityPublisher.cpp
+++ b/teleop/src/VelocityPublisher.cpp
@@ -1,0 +1,222 @@
+/*
+Copyright (c) 2019, ROSIN-project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <mutex>
+#include <string>
+#include <stdio.h>
+#include <Scheduler.h>
+#include <boost/bind.hpp>
+#include <ros/ros.h>
+#include <ros/console.h>
+#include <teleop_msgs/Joystick.h>
+#include <teleop_msgs/Keyboard.h>
+#include <geometry_msgs/Twist.h>
+#include "JoystickPublisher.h"
+#include "KeyboardPublisher.h"
+
+
+class VelocityPublisher {
+private:
+    std::mutex mutex;
+    Bosma::Scheduler scheduler;
+    ros::NodeHandle nodeHandle;
+    ros::Publisher cmdVelPublisher;
+    ros::Subscriber joystickSubscriber;
+    ros::Subscriber keyboardSubscriber;
+    int publishEveryMs;
+    double minVelLinear;
+    double maxVelLinear;
+    double minVelAngular;
+    double maxVelAngular;
+    double deltaVelLinear;
+    double deltaVelAngular;
+    double currVelLinear;
+    double currVelAngular;
+
+    // Callback functions for ROS topics.
+    void schedulerCB();
+    void joystickCB(const teleop_msgs::Joystick& joy);
+    void keyboardCB(const teleop_msgs::Keyboard& key);
+
+public:
+    VelocityPublisher(int argc, char** argv);
+    virtual ~VelocityPublisher() {};
+    void run() {ros::spin();}
+};
+
+VelocityPublisher::VelocityPublisher(int argc, char** argv) :
+    cmdVelPublisher(nodeHandle.advertise<geometry_msgs::Twist>("/cmd_vel", 10)),
+    joystickSubscriber(nodeHandle.subscribe("/joystick", 10, &VelocityPublisher::joystickCB, this)),
+    keyboardSubscriber(nodeHandle.subscribe("/keyboard", 10, &VelocityPublisher::keyboardCB, this))
+{
+    nodeHandle.param("/velocity_publisher/publish_every_ms", publishEveryMs, 100);
+    nodeHandle.param("/velocity_publisher/min_vel_linear", minVelLinear, 0.04); // m/s
+    nodeHandle.param("/velocity_publisher/max_vel_linear", maxVelLinear, 0.10); // m/s
+    nodeHandle.param("/velocity_publisher/min_vel_angular", minVelAngular, 0.64); // rad/s
+    nodeHandle.param("/velocity_publisher/max_vel_angular", maxVelAngular, 1.60); // rad/s
+    deltaVelLinear = (maxVelLinear - minVelLinear) / 10.0;
+    deltaVelAngular = (maxVelAngular - minVelAngular) / 10.0;
+    currVelLinear = 0.0;
+    currVelAngular = 0.0;
+
+    printf("publish_every_ms: %d\n", publishEveryMs);
+    printf("min_vel_linear: %f m/s\n", minVelLinear);
+    printf("max_vel_linear: %f m/s\n", maxVelLinear);
+    printf("min_vel_angular: %f rad/s\n", minVelAngular);
+    printf("max_vel_angular: %f rad/s\n", maxVelAngular);
+
+    scheduler.every(std::chrono::milliseconds(publishEveryMs), boost::bind(&VelocityPublisher::schedulerCB, this));
+}
+
+
+void VelocityPublisher::schedulerCB()
+{
+    std::lock_guard<std::mutex> guard(mutex);
+
+    geometry_msgs::Twist vel;
+    vel.linear.x = currVelLinear;
+    vel.angular.z = currVelAngular;
+    cmdVelPublisher.publish(vel);
+}
+
+
+void VelocityPublisher::joystickCB(const teleop_msgs::Joystick& joy)
+{
+    std::lock_guard<std::mutex> guard(mutex);
+
+    JoystickEvents event = static_cast<JoystickEvents>(joy.event);
+    switch (event) {
+        case JS_EVENT_BUTTON0_DOWN:
+            currVelLinear = 0.0;
+            currVelAngular = 0.0;
+            break;
+        case JS_EVENT_BUTTON1_DOWN:
+            currVelLinear = 0.0;
+            currVelAngular = 0.0;
+            break;
+        case JS_EVENT_AXIS_UP:
+            currVelLinear += deltaVelLinear;
+            if (currVelLinear > maxVelLinear) {
+                currVelLinear = maxVelLinear;
+            }
+            else if (currVelLinear > -minVelLinear && currVelLinear < minVelLinear) {
+                currVelLinear = minVelLinear;
+            }
+            break;
+        case JS_EVENT_AXIS_DOWN:
+            currVelLinear -= deltaVelLinear;
+            if (currVelLinear < -maxVelLinear) {
+                currVelLinear = -maxVelLinear;
+            }
+            else if (currVelLinear > -minVelLinear && currVelLinear < minVelLinear) {
+                currVelLinear = -minVelLinear;
+            }
+            break;
+        case JS_EVENT_AXIS_LEFT:
+            currVelAngular -= deltaVelAngular;
+            if (currVelAngular < -maxVelAngular) {
+                currVelAngular = -maxVelAngular;
+            }
+            else if (currVelAngular > -minVelAngular && currVelAngular < minVelAngular) {
+                currVelAngular = -minVelAngular;
+            }
+            break;
+        case JS_EVENT_AXIS_RIGHT:
+            currVelAngular += deltaVelAngular;
+            if (currVelAngular > maxVelAngular) {
+                currVelAngular = maxVelAngular;
+            }
+            else if (currVelAngular > -minVelAngular && currVelAngular < minVelAngular) {
+                currVelAngular = minVelAngular;
+            }
+            break;
+        default:
+            break;
+    }
+}
+
+
+void VelocityPublisher::keyboardCB(const teleop_msgs::Keyboard& key)
+{
+    std::lock_guard<std::mutex> guard(mutex);
+
+    KeyboardEvents event = static_cast<KeyboardEvents>(key.event);
+    switch (event) {
+        case KB_EVENT_UP:
+            currVelLinear += deltaVelLinear;
+            if (currVelLinear > maxVelLinear) {
+                currVelLinear = maxVelLinear;
+            }
+            else if (currVelLinear > -minVelLinear && currVelLinear < minVelLinear) {
+                currVelLinear = minVelLinear;
+            }
+            break;
+        case KB_EVENT_LEFT:
+            currVelAngular -= deltaVelAngular;
+            if (currVelAngular < -maxVelAngular) {
+                currVelAngular = -maxVelAngular;
+            }
+            else if (currVelAngular > -minVelAngular && currVelAngular < minVelAngular) {
+                currVelAngular = -minVelAngular;
+            }
+            break;
+        case KB_EVENT_RIGHT:
+            currVelAngular += deltaVelAngular;
+            if (currVelAngular > maxVelAngular) {
+                currVelAngular = maxVelAngular;
+            }
+            else if (currVelAngular > -minVelAngular && currVelAngular < minVelAngular) {
+                currVelAngular = minVelAngular;
+            }
+            break;
+        case KB_EVENT_DOWN:
+            currVelLinear -= deltaVelLinear;
+            if (currVelLinear < -maxVelLinear) {
+                currVelLinear = -maxVelLinear;
+            }
+            else if (currVelLinear > -minVelLinear && currVelLinear < minVelLinear) {
+                currVelLinear = -minVelLinear;
+            }
+            break;
+        case KB_EVENT_SPACE:
+            currVelLinear = 0.0;
+            currVelAngular = 0.0;
+            break;
+        default:
+            break;
+    }
+}
+
+
+int main(int argc, char** argv) {
+    ros::init(argc, argv, "velocity_publisher"); // Name of this node.
+    VelocityPublisher velocityPublisher(argc, argv);
+    velocityPublisher.run();
+}

--- a/teleop/src/VelocityPublisher.cpp
+++ b/teleop/src/VelocityPublisher.cpp
@@ -31,7 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <mutex>
 #include <string>
 #include <stdio.h>
-#include <Scheduler.h>
+#include "ext/Scheduler.h"
 #include <boost/bind.hpp>
 #include <ros/ros.h>
 #include <ros/console.h>

--- a/teleop/src/VelocityPublisher_rx.cpp
+++ b/teleop/src/VelocityPublisher_rx.cpp
@@ -1,0 +1,100 @@
+/*
+Copyright (c) 2019, ROSIN-project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <rxros.h>
+#include <teleop_msgs/Joystick.h>
+#include <teleop_msgs/Keyboard.h>
+#include <geometry_msgs/Twist.h>
+#include "JoystickPublisher.h"
+#include "KeyboardPublisher.h"
+using namespace rxcpp::operators;
+using namespace rxros::operators;
+
+
+int main(int argc, char** argv) {
+    rxros::init(argc, argv, "velocity_publisher"); // Name of this node.
+
+    const auto frequencyInHz = rxros::parameter::get("/velocity_publisher/frequency", 10.0); // hz
+    const auto minVelLinear = rxros::parameter::get("/velocity_publisher/min_vel_linear", 0.04); // m/s
+    const auto maxVelLinear = rxros::parameter::get("/velocity_publisher/max_vel_linear", 0.10); // m/s
+    const auto minVelAngular = rxros::parameter::get("/velocity_publisher/min_vel_angular", 0.64); // rad/s
+    const auto maxVelAngular = rxros::parameter::get("/velocity_publisher/max_vel_angular", 1.60); // rad/s
+    const auto deltaVelLinear = (maxVelLinear - minVelLinear) / 10.0;
+    const auto deltaVelAngular = (maxVelAngular - minVelAngular) / 10.0;
+
+    rxros::logging().info() << "frequency: " << frequencyInHz;
+    rxros::logging().info() << "min_vel_linear: " << minVelLinear << " m/s";
+    rxros::logging().info() << "max_vel_linear: " << maxVelLinear << " m/s";
+    rxros::logging().info() << "min_vel_angular: " << minVelAngular << " rad/s";
+    rxros::logging().info() << "max_vel_angular: " << maxVelAngular << " rad/s";
+
+    auto adaptVelocity = [=] (auto newVel, auto minVel, auto maxVel, auto isIncrVel) {
+        if (newVel > maxVel)
+            return maxVel;
+        else if (newVel < -maxVel)
+            return -maxVel;
+        else if (newVel > -minVel && newVel < minVel)
+            return (isIncrVel) ? minVel : -minVel;
+        else
+            return newVel;};
+
+    auto teleop2VelTuple = [=](const auto& prevVelTuple, const int event) {
+        const auto prevVelLinear = std::get<0>(prevVelTuple);  // use previous linear and angular velocity
+        const auto prevVelAngular = std::get<1>(prevVelTuple); // to calculate the new linear and angular velocity.
+        if (event == JS_EVENT_BUTTON0_DOWN || event == JS_EVENT_BUTTON1_DOWN || event == KB_EVENT_SPACE)
+            return std::make_tuple(0.0, 0.0); // Stop the robot
+        else if (event == JS_EVENT_AXIS_UP || event == KB_EVENT_UP)
+            return std::make_tuple(adaptVelocity((prevVelLinear + deltaVelLinear), minVelLinear, maxVelLinear, true), prevVelAngular); // move forward
+        else if (event == JS_EVENT_AXIS_DOWN || event == KB_EVENT_DOWN)
+            return std::make_tuple(adaptVelocity((prevVelLinear - deltaVelLinear), minVelLinear, maxVelLinear, false), prevVelAngular); // move backward
+        else if (event == JS_EVENT_AXIS_LEFT || event == KB_EVENT_LEFT)
+            return std::make_tuple(prevVelLinear, adaptVelocity((prevVelAngular + deltaVelAngular), minVelAngular, maxVelAngular, true)); // move left
+        else if (event == JS_EVENT_AXIS_RIGHT || event == KB_EVENT_RIGHT)
+            return std::make_tuple(prevVelLinear, adaptVelocity((prevVelAngular - deltaVelAngular), minVelAngular, maxVelAngular, false));}; // move right
+
+    auto velTuple2TwistMsg = [](auto velTuple) {
+        geometry_msgs::Twist vel;
+        vel.linear.x = std::get<0>(velTuple);
+        vel.angular.z = std::get<1>(velTuple);
+        return vel;};
+
+    auto joyObsrv = rxros::observable::from_topic<teleop_msgs::Joystick>("/joystick") // create an observable stream from "/joystick" topic
+        | map([](teleop_msgs::Joystick joy) { return joy.event; });
+    auto keyObsrv = rxros::observable::from_topic<teleop_msgs::Keyboard>("/keyboard") // create an observable stream from "/keyboard" topic
+        | map([](teleop_msgs::Keyboard key) { return key.event; });
+    joyObsrv.merge(keyObsrv)                              // merge the joystick and keyboard messages into an observable teleop stream.
+    | scan(std::make_tuple(0.0, 0.0), teleop2VelTuple)    // turn the teleop stream into a linear and angular velocity stream.
+    | map(velTuple2TwistMsg)                              // turn the linear and angular velocity stream into a Twist stream.
+    | sample_with_frequency(frequencyInHz)                // take latest Twist msg and populate it with the specified frequency.
+    | publish_to_topic<geometry_msgs::Twist>("/cmd_vel"); // publish the Twist messages to the topic "/cmd_vel"
+
+    rxros::logging().info() << "Spinning velocity_publisher ...";
+    rxros::spin();
+}

--- a/teleop/src/VelocityPublisher_rx.cpp
+++ b/teleop/src/VelocityPublisher_rx.cpp
@@ -28,7 +28,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <rxros.h>
+#include <rxros/rxros.h>
 #include <teleop_msgs/Joystick.h>
 #include <teleop_msgs/Keyboard.h>
 #include <geometry_msgs/Twist.h>

--- a/teleop/src/ext/Cron.h
+++ b/teleop/src/ext/Cron.h
@@ -1,0 +1,121 @@
+#include <chrono>
+#include <string>
+#include <sstream>
+#include <vector>
+#include <iterator>
+
+namespace Bosma {
+    using Clock = std::chrono::system_clock;
+
+    inline void add(std::tm &tm, Clock::duration time) {
+      auto tp = Clock::from_time_t(std::mktime(&tm));
+      auto tp_adjusted = tp + time;
+      auto tm_adjusted = Clock::to_time_t(tp_adjusted);
+      tm = *std::localtime(&tm_adjusted);
+    }
+
+    class BadCronExpression : public std::exception {
+    public:
+        explicit BadCronExpression(std::string msg) : msg_(std::move(msg)) {}
+
+        const char *what() const noexcept override { return (msg_.c_str()); }
+
+    private:
+        std::string msg_;
+    };
+
+    inline void
+    verify_and_set(const std::string &token, const std::string &expression, int &field, const int lower_bound,
+                   const int upper_bound, const bool adjust = false) {
+      if (token == "*")
+        field = -1;
+      else {
+        try {
+          field = std::stoi(token);
+        } catch (const std::invalid_argument &) {
+          throw BadCronExpression("malformed cron string (`" + token + "` not an integer or *): " + expression);
+        } catch (const std::out_of_range &) {
+          throw BadCronExpression("malformed cron string (`" + token + "` not convertable to int): " + expression);
+        }
+        if (field < lower_bound || field > upper_bound) {
+          std::ostringstream oss;
+          oss << "malformed cron string ('" << token << "' must be <= " << upper_bound << " and >= " << lower_bound
+              << "): " << expression;
+          throw BadCronExpression(oss.str());
+        }
+        if (adjust)
+          field--;
+      }
+    }
+
+    class Cron {
+    public:
+        explicit Cron(const std::string &expression) {
+          std::istringstream iss(expression);
+          std::vector<std::string> tokens{std::istream_iterator<std::string>{iss},
+                                          std::istream_iterator<std::string>{}};
+
+          if (tokens.size() != 5) throw BadCronExpression("malformed cron string (must be 5 fields): " + expression);
+
+          verify_and_set(tokens[0], expression, minute, 0, 59);
+          verify_and_set(tokens[1], expression, hour, 0, 23);
+          verify_and_set(tokens[2], expression, day, 1, 31);
+          verify_and_set(tokens[3], expression, month, 1, 12, true);
+          verify_and_set(tokens[4], expression, day_of_week, 0, 6);
+        }
+
+        // http://stackoverflow.com/a/322058/1284550
+        Clock::time_point cron_to_next(const Clock::time_point from = Clock::now()) const {
+          // get current time as a tm object
+          auto now = Clock::to_time_t(from);
+          std::tm next(*std::localtime(&now));
+          // it will always at least run the next minute
+          next.tm_sec = 0;
+          add(next, std::chrono::minutes(1));
+          while (true) {
+            if (month != -1 && next.tm_mon != month) {
+              // add a month
+              // if this will bring us over a year, increment the year instead and reset the month
+              if (next.tm_mon + 1 > 11) {
+                next.tm_mon = 0;
+                next.tm_year++;
+              } else
+                next.tm_mon++;
+
+              next.tm_mday = 1;
+              next.tm_hour = 0;
+              next.tm_min = 0;
+              continue;
+            }
+            if (day != -1 && next.tm_mday != day) {
+              add(next, std::chrono::hours(24));
+              next.tm_hour = 0;
+              next.tm_min = 0;
+              continue;
+            }
+            if (day_of_week != -1 && next.tm_wday != day_of_week) {
+              add(next, std::chrono::hours(24));
+              next.tm_hour = 0;
+              next.tm_min = 0;
+              continue;
+            }
+            if (hour != -1 && next.tm_hour != hour) {
+              add(next, std::chrono::hours(1));
+              next.tm_min = 0;
+              continue;
+            }
+            if (minute != -1 && next.tm_min != minute) {
+              add(next, std::chrono::minutes(1));
+              continue;
+            }
+            break;
+          }
+
+          // telling mktime to figure out dst
+          next.tm_isdst = -1;
+          return Clock::from_time_t(std::mktime(&next));
+        }
+
+        int minute, hour, day, month, day_of_week;
+    };
+}

--- a/teleop/src/ext/InterruptableSleep.h
+++ b/teleop/src/ext/InterruptableSleep.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <chrono>
+#include <thread>
+#include <future>
+#include <mutex>
+#include <sstream>
+
+namespace Bosma {
+    class InterruptableSleep {
+
+        using Clock = std::chrono::system_clock;
+
+        // InterruptableSleep offers a sleep that can be interrupted by any thread.
+        // It can be interrupted multiple times
+        // and be interrupted before any sleep is called (the sleep will immediately complete)
+        // Has same interface as condition_variables and futures, except with sleep instead of wait.
+        // For a given object, sleep can be called on multiple threads safely, but is not recommended as behaviour is undefined.
+
+    public:
+        InterruptableSleep() : interrupted(false) {
+        }
+
+        InterruptableSleep(const InterruptableSleep &) = delete;
+
+        InterruptableSleep(InterruptableSleep &&) noexcept = delete;
+
+        ~InterruptableSleep() noexcept = default;
+
+        InterruptableSleep &operator=(const InterruptableSleep &) noexcept = delete;
+
+        InterruptableSleep &operator=(InterruptableSleep &&) noexcept = delete;
+
+        void sleep_for(Clock::duration duration) {
+          std::unique_lock<std::mutex> ul(m);
+          cv.wait_for(ul, duration, [this] { return interrupted; });
+          interrupted = false;
+        }
+
+        void sleep_until(Clock::time_point time) {
+          std::unique_lock<std::mutex> ul(m);
+          cv.wait_until(ul, time, [this] { return interrupted; });
+          interrupted = false;
+        }
+
+        void sleep() {
+          std::unique_lock<std::mutex> ul(m);
+          cv.wait(ul, [this] { return interrupted; });
+          interrupted = false;
+        }
+
+        void interrupt() {
+          std::lock_guard<std::mutex> lg(m);
+          interrupted = true;
+          cv.notify_one();
+        }
+
+    private:
+        bool interrupted;
+        std::mutex m;
+        std::condition_variable cv;
+    };
+}

--- a/teleop/src/ext/Scheduler.h
+++ b/teleop/src/ext/Scheduler.h
@@ -1,0 +1,221 @@
+#pragma once
+
+#include <iomanip>
+#include <map>
+
+#include "ctpl_stl.h"
+
+#include "InterruptableSleep.h"
+#include "Cron.h"
+
+namespace Bosma {
+    using Clock = std::chrono::system_clock;
+
+    class Task {
+    public:
+        explicit Task(std::function<void()> &&f, bool recur = false, bool interval = false) :
+                f(std::move(f)), recur(recur), interval(interval) {}
+
+        virtual Clock::time_point get_new_time() const = 0;
+
+        std::function<void()> f;
+
+        bool recur;
+        bool interval;
+    };
+
+    class InTask : public Task {
+    public:
+        explicit InTask(std::function<void()> &&f) : Task(std::move(f)) {}
+
+        // dummy time_point because it's not used
+        Clock::time_point get_new_time() const override { return Clock::time_point(Clock::duration(0)); }
+    };
+
+    class EveryTask : public Task {
+    public:
+        EveryTask(Clock::duration time, std::function<void()> &&f, bool interval = false) :
+                Task(std::move(f), true, interval), time(time) {}
+
+        Clock::time_point get_new_time() const override {
+          return Clock::now() + time;
+        };
+        Clock::duration time;
+    };
+
+    class CronTask : public Task {
+    public:
+        CronTask(const std::string &expression, std::function<void()> &&f) : Task(std::move(f), true),
+                                                                             cron(expression) {}
+
+        Clock::time_point get_new_time() const override {
+          return cron.cron_to_next();
+        };
+        Cron cron;
+    };
+
+    inline bool try_parse(std::tm &tm, const std::string &expression, const std::string &format) {
+      std::stringstream ss(expression);
+      return !(ss >> std::get_time(&tm, format.c_str())).fail();
+    }
+
+    class Scheduler {
+    public:
+        explicit Scheduler(unsigned int max_n_tasks = 4) : done(false), threads(max_n_tasks + 1) {
+          threads.push([this](int) {
+              while (!done) {
+                if (tasks.empty()) {
+                  sleeper.sleep();
+                } else {
+                  auto time_of_first_task = (*tasks.begin()).first;
+                  sleeper.sleep_until(time_of_first_task);
+                }
+                manage_tasks();
+              }
+          });
+        }
+
+        Scheduler(const Scheduler &) = delete;
+
+        Scheduler(Scheduler &&) noexcept = delete;
+
+        Scheduler &operator=(const Scheduler &) = delete;
+
+        Scheduler &operator=(Scheduler &&) noexcept = delete;
+
+        ~Scheduler() {
+          done = true;
+          sleeper.interrupt();
+        }
+
+        template<typename _Callable, typename... _Args>
+        void in(const Clock::time_point time, _Callable &&f, _Args &&... args) {
+          std::shared_ptr<Task> t = std::make_shared<InTask>(
+                  std::bind(std::forward<_Callable>(f), std::forward<_Args>(args)...));
+          add_task(time, std::move(t));
+        }
+
+        template<typename _Callable, typename... _Args>
+        void in(const Clock::duration time, _Callable &&f, _Args &&... args) {
+          in(Clock::now() + time, std::forward<_Callable>(f), std::forward<_Args>(args)...);
+        }
+
+        template<typename _Callable, typename... _Args>
+        void at(const std::string &time, _Callable &&f, _Args &&... args) {
+          // get current time as a tm object
+          auto time_now = Clock::to_time_t(Clock::now());
+          std::tm tm = *std::localtime(&time_now);
+
+          // our final time as a time_point
+          Clock::time_point tp;
+
+          if (try_parse(tm, time, "%H:%M:%S")) {
+            // convert tm back to time_t, then to a time_point and assign to final
+            tp = Clock::from_time_t(std::mktime(&tm));
+
+            // if we've already passed this time, the user will mean next day, so add a day.
+            if (Clock::now() >= tp)
+              tp += std::chrono::hours(24);
+          } else if (try_parse(tm, time, "%Y-%m-%d %H:%M:%S")) {
+            tp = Clock::from_time_t(std::mktime(&tm));
+          } else if (try_parse(tm, time, "%Y/%m/%d %H:%M:%S")) {
+            tp = Clock::from_time_t(std::mktime(&tm));
+          } else {
+            // could not parse time
+            throw std::runtime_error("Cannot parse time string: " + time);
+          }
+
+          in(tp, std::forward<_Callable>(f), std::forward<_Args>(args)...);
+        }
+
+        template<typename _Callable, typename... _Args>
+        void every(const Clock::duration time, _Callable &&f, _Args &&... args) {
+          std::shared_ptr<Task> t = std::make_shared<EveryTask>(time, std::bind(std::forward<_Callable>(f),
+                                                                                std::forward<_Args>(args)...));
+          auto next_time = t->get_new_time();
+          add_task(next_time, std::move(t));
+        }
+
+// expression format:
+// from https://en.wikipedia.org/wiki/Cron#Overview
+//    ┌───────────── minute (0 - 59)
+//    │ ┌───────────── hour (0 - 23)
+//    │ │ ┌───────────── day of month (1 - 31)
+//    │ │ │ ┌───────────── month (1 - 12)
+//    │ │ │ │ ┌───────────── day of week (0 - 6) (Sunday to Saturday)
+//    │ │ │ │ │
+//    │ │ │ │ │
+//    * * * * *
+        template<typename _Callable, typename... _Args>
+        void cron(const std::string &expression, _Callable &&f, _Args &&... args) {
+          std::shared_ptr<Task> t = std::make_shared<CronTask>(expression, std::bind(std::forward<_Callable>(f),
+                                                                                     std::forward<_Args>(args)...));
+          auto next_time = t->get_new_time();
+          add_task(next_time, std::move(t));
+        }
+
+        template<typename _Callable, typename... _Args>
+        void interval(const Clock::duration time, _Callable &&f, _Args &&... args) {
+          std::shared_ptr<Task> t = std::make_shared<EveryTask>(time, std::bind(std::forward<_Callable>(f),
+                                                                                std::forward<_Args>(args)...), true);
+          add_task(Clock::now(), std::move(t));
+        }
+
+    private:
+        std::atomic<bool> done;
+
+        Bosma::InterruptableSleep sleeper;
+
+        std::multimap<Clock::time_point, std::shared_ptr<Task>> tasks;
+        std::mutex lock;
+        ctpl::thread_pool threads;
+
+        void add_task(const Clock::time_point time, std::shared_ptr<Task> t) {
+          std::lock_guard<std::mutex> l(lock);
+          tasks.emplace(time, std::move(t));
+          sleeper.interrupt();
+        }
+
+        void manage_tasks() {
+          std::lock_guard<std::mutex> l(lock);
+
+          auto end_of_tasks_to_run = tasks.upper_bound(Clock::now());
+
+          // if there are any tasks to be run and removed
+          if (end_of_tasks_to_run != tasks.begin()) {
+            // keep track of tasks that will be re-added
+            decltype(tasks) recurred_tasks;
+
+            // for all tasks that have been triggered
+            for (auto i = tasks.begin(); i != end_of_tasks_to_run; ++i) {
+
+              auto &task = (*i).second;
+
+              if (task->interval) {
+                // if it's an interval task, only add the task back after f() is completed
+                threads.push([this, task](int) {
+                    task->f();
+                    // no risk of race-condition,
+                    // add_task() will wait for manage_tasks() to release lock
+                    add_task(task->get_new_time(), task);
+                });
+              } else {
+                threads.push([task](int) {
+                    task->f();
+                });
+                // calculate time of next run and add the new task to the tasks to be recurred
+                if (task->recur)
+                  recurred_tasks.emplace(task->get_new_time(), std::move(task));
+              }
+            }
+
+            // remove the completed tasks
+            tasks.erase(tasks.begin(), end_of_tasks_to_run);
+
+            // re-add the tasks that are recurring
+            for (auto &task : recurred_tasks)
+              tasks.emplace(task.first, std::move(task.second));
+          }
+        }
+    };
+}

--- a/teleop/src/ext/ctpl.h
+++ b/teleop/src/ext/ctpl.h
@@ -1,0 +1,240 @@
+
+/*********************************************************
+ *
+ *  Copyright (C) 2014 by Vitaliy Vitsentiy
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *********************************************************/
+
+
+#ifndef __ctpl_thread_pool_H__
+#define __ctpl_thread_pool_H__
+
+#include <functional>
+#include <thread>
+#include <atomic>
+#include <vector>
+#include <memory>
+#include <exception>
+#include <future>
+#include <mutex>
+#include <boost/lockfree/queue.hpp>
+
+
+#ifndef _ctplThreadPoolLength_
+#define _ctplThreadPoolLength_  100
+#endif
+
+
+// thread pool to run user's functors with signature
+//      ret func(int id, other_params)
+// where id is the index of the thread that runs the functor
+// ret is some return type
+
+
+namespace ctpl {
+
+    class thread_pool {
+
+    public:
+
+        thread_pool() : q(_ctplThreadPoolLength_) { this->init(); }
+        thread_pool(int nThreads, int queueSize = _ctplThreadPoolLength_) : q(queueSize) { this->init(); this->resize(nThreads); }
+
+        // the destructor waits for all the functions in the queue to be finished
+        ~thread_pool() {
+            this->stop(true);
+        }
+
+        // get the number of running threads in the pool
+        int size() { return static_cast<int>(this->threads.size()); }
+
+        // number of idle threads
+        int n_idle() { return this->nWaiting; }
+        std::thread & get_thread(int i) { return *this->threads[i]; }
+
+        // change the number of threads in the pool
+        // should be called from one thread, otherwise be careful to not interleave, also with this->stop()
+        // nThreads must be >= 0
+        void resize(int nThreads) {
+            if (!this->isStop && !this->isDone) {
+                int oldNThreads = static_cast<int>(this->threads.size());
+                if (oldNThreads <= nThreads) {  // if the number of threads is increased
+                    this->threads.resize(nThreads);
+                    this->flags.resize(nThreads);
+
+                    for (int i = oldNThreads; i < nThreads; ++i) {
+                        this->flags[i] = std::make_shared<std::atomic<bool>>(false);
+                        this->set_thread(i);
+                    }
+                }
+                else {  // the number of threads is decreased
+                    for (int i = oldNThreads - 1; i >= nThreads; --i) {
+                        *this->flags[i] = true;  // this thread will finish
+                        this->threads[i]->detach();
+                    }
+                    {
+                        // stop the detached threads that were waiting
+                        std::unique_lock<std::mutex> lock(this->mutex);
+                        this->cv.notify_all();
+                    }
+                    this->threads.resize(nThreads);  // safe to delete because the threads are detached
+                    this->flags.resize(nThreads);  // safe to delete because the threads have copies of shared_ptr of the flags, not originals
+                }
+            }
+        }
+
+        // empty the queue
+        void clear_queue() {
+            std::function<void(int id)> * _f;
+            while (this->q.pop(_f))
+                delete _f;  // empty the queue
+        }
+
+        // pops a functional wraper to the original function
+        std::function<void(int)> pop() {
+            std::function<void(int id)> * _f = nullptr;
+            this->q.pop(_f);
+            std::unique_ptr<std::function<void(int id)>> func(_f);  // at return, delete the function even if an exception occurred
+            
+            std::function<void(int)> f;
+            if (_f)
+                f = *_f;
+            return f;
+        }
+
+
+        // wait for all computing threads to finish and stop all threads
+        // may be called asyncronously to not pause the calling thread while waiting
+        // if isWait == true, all the functions in the queue are run, otherwise the queue is cleared without running the functions
+        void stop(bool isWait = false) {
+            if (!isWait) {
+                if (this->isStop)
+                    return;
+                this->isStop = true;
+                for (int i = 0, n = this->size(); i < n; ++i) {
+                    *this->flags[i] = true;  // command the threads to stop
+                }
+                this->clear_queue();  // empty the queue
+            }
+            else {
+                if (this->isDone || this->isStop)
+                    return;
+                this->isDone = true;  // give the waiting threads a command to finish
+            }
+            {
+                std::unique_lock<std::mutex> lock(this->mutex);
+                this->cv.notify_all();  // stop all waiting threads
+            }
+            for (int i = 0; i < static_cast<int>(this->threads.size()); ++i) {  // wait for the computing threads to finish
+                if (this->threads[i]->joinable())
+                    this->threads[i]->join();
+            }
+            // if there were no threads in the pool but some functors in the queue, the functors are not deleted by the threads
+            // therefore delete them here
+            this->clear_queue();
+            this->threads.clear();
+            this->flags.clear();
+        }
+
+        template<typename F, typename... Rest>
+        auto push(F && f, Rest&&... rest) ->std::future<decltype(f(0, rest...))> {
+            auto pck = std::make_shared<std::packaged_task<decltype(f(0, rest...))(int)>>(
+                std::bind(std::forward<F>(f), std::placeholders::_1, std::forward<Rest>(rest)...)
+            );
+
+            auto _f = new std::function<void(int id)>([pck](int id) {
+                (*pck)(id);
+            });
+            this->q.push(_f);
+
+            std::unique_lock<std::mutex> lock(this->mutex);
+            this->cv.notify_one();
+
+            return pck->get_future();
+        }
+
+        // run the user's function that excepts argument int - id of the running thread. returned value is templatized
+        // operator returns std::future, where the user can get the result and rethrow the catched exceptins
+        template<typename F>
+        auto push(F && f) ->std::future<decltype(f(0))> {
+            auto pck = std::make_shared<std::packaged_task<decltype(f(0))(int)>>(std::forward<F>(f));
+
+            auto _f = new std::function<void(int id)>([pck](int id) {
+                (*pck)(id);
+            });
+            this->q.push(_f);
+
+            std::unique_lock<std::mutex> lock(this->mutex);
+            this->cv.notify_one();
+
+            return pck->get_future();
+        }
+
+
+    private:
+
+        // deleted
+        thread_pool(const thread_pool &);// = delete;
+        thread_pool(thread_pool &&);// = delete;
+        thread_pool & operator=(const thread_pool &);// = delete;
+        thread_pool & operator=(thread_pool &&);// = delete;
+
+        void set_thread(int i) {
+            std::shared_ptr<std::atomic<bool>> flag(this->flags[i]);  // a copy of the shared ptr to the flag
+            auto f = [this, i, flag/* a copy of the shared ptr to the flag */]() {
+                std::atomic<bool> & _flag = *flag;
+                std::function<void(int id)> * _f;
+                bool isPop = this->q.pop(_f);
+                while (true) {
+                    while (isPop) {  // if there is anything in the queue
+                        std::unique_ptr<std::function<void(int id)>> func(_f);  // at return, delete the function even if an exception occurred
+                        (*_f)(i);
+
+                        if (_flag)
+                            return;  // the thread is wanted to stop, return even if the queue is not empty yet
+                        else
+                            isPop = this->q.pop(_f);
+                    }
+
+                    // the queue is empty here, wait for the next command
+                    std::unique_lock<std::mutex> lock(this->mutex);
+                    ++this->nWaiting;
+                    this->cv.wait(lock, [this, &_f, &isPop, &_flag](){ isPop = this->q.pop(_f); return isPop || this->isDone || _flag; });
+                    --this->nWaiting;
+
+                    if (!isPop)
+                        return;  // if the queue is empty and this->isDone == true or *flag then return
+                }
+            };
+            this->threads[i].reset(new std::thread(f));  // compiler may not support std::make_unique()
+        }
+
+        void init() { this->nWaiting = 0; this->isStop = false; this->isDone = false; }
+
+        std::vector<std::unique_ptr<std::thread>> threads;
+        std::vector<std::shared_ptr<std::atomic<bool>>> flags;
+        mutable boost::lockfree::queue<std::function<void(int id)> *> q;
+        std::atomic<bool> isDone;
+        std::atomic<bool> isStop;
+        std::atomic<int> nWaiting;  // how many threads are waiting
+
+        std::mutex mutex;
+        std::condition_variable cv;
+    };
+
+}
+
+#endif // __ctpl_thread_pool_H__
+

--- a/teleop/src/ext/ctpl_stl.h
+++ b/teleop/src/ext/ctpl_stl.h
@@ -1,0 +1,251 @@
+/*********************************************************
+*
+*  Copyright (C) 2014 by Vitaliy Vitsentiy
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*********************************************************/
+
+
+#ifndef __ctpl_stl_thread_pool_H__
+#define __ctpl_stl_thread_pool_H__
+
+#include <functional>
+#include <thread>
+#include <atomic>
+#include <vector>
+#include <memory>
+#include <exception>
+#include <future>
+#include <mutex>
+#include <queue>
+
+
+
+// thread pool to run user's functors with signature
+//      ret func(int id, other_params)
+// where id is the index of the thread that runs the functor
+// ret is some return type
+
+
+namespace ctpl {
+
+    namespace detail {
+        template <typename T>
+        class Queue {
+        public:
+            bool push(T const & value) {
+                std::unique_lock<std::mutex> lock(this->mutex);
+                this->q.push(value);
+                return true;
+            }
+            // deletes the retrieved element, do not use for non integral types
+            bool pop(T & v) {
+                std::unique_lock<std::mutex> lock(this->mutex);
+                if (this->q.empty())
+                    return false;
+                v = this->q.front();
+                this->q.pop();
+                return true;
+            }
+            bool empty() {
+                std::unique_lock<std::mutex> lock(this->mutex);
+                return this->q.empty();
+            }
+        private:
+            std::queue<T> q;
+            std::mutex mutex;
+        };
+    }
+
+    class thread_pool {
+
+    public:
+
+        thread_pool() { this->init(); }
+        thread_pool(int nThreads) { this->init(); this->resize(nThreads); }
+
+        // the destructor waits for all the functions in the queue to be finished
+        ~thread_pool() {
+            this->stop(true);
+        }
+
+        // get the number of running threads in the pool
+        int size() { return static_cast<int>(this->threads.size()); }
+
+        // number of idle threads
+        int n_idle() { return this->nWaiting; }
+        std::thread & get_thread(int i) { return *this->threads[i]; }
+
+        // change the number of threads in the pool
+        // should be called from one thread, otherwise be careful to not interleave, also with this->stop()
+        // nThreads must be >= 0
+        void resize(int nThreads) {
+            if (!this->isStop && !this->isDone) {
+                int oldNThreads = static_cast<int>(this->threads.size());
+                if (oldNThreads <= nThreads) {  // if the number of threads is increased
+                    this->threads.resize(nThreads);
+                    this->flags.resize(nThreads);
+
+                    for (int i = oldNThreads; i < nThreads; ++i) {
+                        this->flags[i] = std::make_shared<std::atomic<bool>>(false);
+                        this->set_thread(i);
+                    }
+                }
+                else {  // the number of threads is decreased
+                    for (int i = oldNThreads - 1; i >= nThreads; --i) {
+                        *this->flags[i] = true;  // this thread will finish
+                        this->threads[i]->detach();
+                    }
+                    {
+                        // stop the detached threads that were waiting
+                        std::unique_lock<std::mutex> lock(this->mutex);
+                        this->cv.notify_all();
+                    }
+                    this->threads.resize(nThreads);  // safe to delete because the threads are detached
+                    this->flags.resize(nThreads);  // safe to delete because the threads have copies of shared_ptr of the flags, not originals
+                }
+            }
+        }
+
+        // empty the queue
+        void clear_queue() {
+            std::function<void(int id)> * _f;
+            while (this->q.pop(_f))
+                delete _f; // empty the queue
+        }
+
+        // pops a functional wrapper to the original function
+        std::function<void(int)> pop() {
+            std::function<void(int id)> * _f = nullptr;
+            this->q.pop(_f);
+            std::unique_ptr<std::function<void(int id)>> func(_f); // at return, delete the function even if an exception occurred
+            std::function<void(int)> f;
+            if (_f)
+                f = *_f;
+            return f;
+        }
+
+        // wait for all computing threads to finish and stop all threads
+        // may be called asynchronously to not pause the calling thread while waiting
+        // if isWait == true, all the functions in the queue are run, otherwise the queue is cleared without running the functions
+        void stop(bool isWait = false) {
+            if (!isWait) {
+                if (this->isStop)
+                    return;
+                this->isStop = true;
+                for (int i = 0, n = this->size(); i < n; ++i) {
+                    *this->flags[i] = true;  // command the threads to stop
+                }
+                this->clear_queue();  // empty the queue
+            }
+            else {
+                if (this->isDone || this->isStop)
+                    return;
+                this->isDone = true;  // give the waiting threads a command to finish
+            }
+            {
+                std::unique_lock<std::mutex> lock(this->mutex);
+                this->cv.notify_all();  // stop all waiting threads
+            }
+            for (int i = 0; i < static_cast<int>(this->threads.size()); ++i) {  // wait for the computing threads to finish
+                    if (this->threads[i]->joinable())
+                        this->threads[i]->join();
+            }
+            // if there were no threads in the pool but some functors in the queue, the functors are not deleted by the threads
+            // therefore delete them here
+            this->clear_queue();
+            this->threads.clear();
+            this->flags.clear();
+        }
+
+        template<typename F, typename... Rest>
+        auto push(F && f, Rest&&... rest) ->std::future<decltype(f(0, rest...))> {
+            auto pck = std::make_shared<std::packaged_task<decltype(f(0, rest...))(int)>>(
+                std::bind(std::forward<F>(f), std::placeholders::_1, std::forward<Rest>(rest)...)
+                );
+            auto _f = new std::function<void(int id)>([pck](int id) {
+                (*pck)(id);
+            });
+            this->q.push(_f);
+            std::unique_lock<std::mutex> lock(this->mutex);
+            this->cv.notify_one();
+            return pck->get_future();
+        }
+
+        // run the user's function that excepts argument int - id of the running thread. returned value is templatized
+        // operator returns std::future, where the user can get the result and rethrow the catched exceptins
+        template<typename F>
+        auto push(F && f) ->std::future<decltype(f(0))> {
+            auto pck = std::make_shared<std::packaged_task<decltype(f(0))(int)>>(std::forward<F>(f));
+            auto _f = new std::function<void(int id)>([pck](int id) {
+                (*pck)(id);
+            });
+            this->q.push(_f);
+            std::unique_lock<std::mutex> lock(this->mutex);
+            this->cv.notify_one();
+            return pck->get_future();
+        }
+
+
+    private:
+
+        // deleted
+        thread_pool(const thread_pool &);// = delete;
+        thread_pool(thread_pool &&);// = delete;
+        thread_pool & operator=(const thread_pool &);// = delete;
+        thread_pool & operator=(thread_pool &&);// = delete;
+
+        void set_thread(int i) {
+            std::shared_ptr<std::atomic<bool>> flag(this->flags[i]); // a copy of the shared ptr to the flag
+            auto f = [this, i, flag/* a copy of the shared ptr to the flag */]() {
+                std::atomic<bool> & _flag = *flag;
+                std::function<void(int id)> * _f;
+                bool isPop = this->q.pop(_f);
+                while (true) {
+                    while (isPop) {  // if there is anything in the queue
+                        std::unique_ptr<std::function<void(int id)>> func(_f); // at return, delete the function even if an exception occurred
+                        (*_f)(i);
+                        if (_flag)
+                            return;  // the thread is wanted to stop, return even if the queue is not empty yet
+                        else
+                            isPop = this->q.pop(_f);
+                    }
+                    // the queue is empty here, wait for the next command
+                    std::unique_lock<std::mutex> lock(this->mutex);
+                    ++this->nWaiting;
+                    this->cv.wait(lock, [this, &_f, &isPop, &_flag](){ isPop = this->q.pop(_f); return isPop || this->isDone || _flag; });
+                    --this->nWaiting;
+                    if (!isPop)
+                        return;  // if the queue is empty and this->isDone == true or *flag then return
+                }
+            };
+            this->threads[i].reset(new std::thread(f)); // compiler may not support std::make_unique()
+        }
+
+        void init() { this->nWaiting = 0; this->isStop = false; this->isDone = false; }
+
+        std::vector<std::unique_ptr<std::thread>> threads;
+        std::vector<std::shared_ptr<std::atomic<bool>>> flags;
+        detail::Queue<std::function<void(int id)> *> q;
+        std::atomic<bool> isDone;
+        std::atomic<bool> isStop;
+        std::atomic<int> nWaiting;  // how many threads are waiting
+
+        std::mutex mutex;
+        std::condition_variable cv;
+    };
+
+}
+
+#endif // __ctpl_stl_thread_pool_H__

--- a/teleop_msgs/CMakeLists.txt
+++ b/teleop_msgs/CMakeLists.txt
@@ -16,7 +16,6 @@ add_message_files (
 generate_messages(
   DEPENDENCIES
     std_msgs
-    teleop_msgs
 )
 
 catkin_package(

--- a/teleop_msgs/CMakeLists.txt
+++ b/teleop_msgs/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(teleop_msgs)
+
+find_package(catkin REQUIRED
+  COMPONENTS
+    message_generation
+    std_msgs
+)
+
+add_message_files (
+  FILES
+    Joystick.msg
+    Keyboard.msg
+)
+
+generate_messages(
+  DEPENDENCIES
+    std_msgs
+    teleop_msgs
+)
+
+catkin_package(
+  CATKIN_DEPENDS
+    message_runtime
+    std_msgs
+)

--- a/teleop_msgs/msg/Joystick.msg
+++ b/teleop_msgs/msg/Joystick.msg
@@ -1,0 +1,2 @@
+time time
+int8 event

--- a/teleop_msgs/msg/Keyboard.msg
+++ b/teleop_msgs/msg/Keyboard.msg
@@ -1,0 +1,2 @@
+time time
+int8 event

--- a/teleop_msgs/package.xml
+++ b/teleop_msgs/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>teleop_msgs</name>
+  <version>0.1.0</version>
+  <description>The RxROS teleop message package</description>
+
+  <maintainer email="wasowski@itu.dk">Andrzej Wasowski</maintainer>
+  <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn</maintainer>
+  <maintainer email="henrik7264@outlook.com">Henrik Larsen</maintainer>
+
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>message_generation</build_depend>
+  <build_depend>std_msgs</build_depend>
+
+  <build_export_depend>std_msgs</build_export_depend>
+
+  <exec_depend>message_runtime</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+</package>

--- a/teleop_msgs/package.xml
+++ b/teleop_msgs/package.xml
@@ -3,20 +3,16 @@
   <name>teleop_msgs</name>
   <version>0.1.0</version>
   <description>The RxROS teleop message package</description>
-
   <maintainer email="wasowski@itu.dk">Andrzej Wasowski</maintainer>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn</maintainer>
   <maintainer email="henrik7264@outlook.com">Henrik Larsen</maintainer>
-
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <depend>std_msgs</depend>
+
   <build_depend>message_generation</build_depend>
-  <build_depend>std_msgs</build_depend>
-
-  <build_export_depend>std_msgs</build_export_depend>
-
+  <build_export_depend>message_runtime</build_export_depend>
   <exec_depend>message_runtime</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
 </package>


### PR DESCRIPTION
As per subject.

Additionally:

 - cleanup manifests and build scripts some more
 - place Bosma Scheduler library in both packages that need it (instead of in the main `rxros` package)
 - add a `.rosinstall` file for convenient workspace setup (`rxros`, `rxcpp_vendor` and `rxros_examples` in the same workspace)
 - make CMake check C++14 support (as it's need to successfully compile the examples)
