### PR TITLE
Add initial Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+sudo: required
+dist: trusty
+language: generic
+
+cache:
+  directories:
+    - $HOME/.ccache
+
+git:
+  quiet: true
+
+env:
+  global:
+    - CCACHE_DIR=$HOME/.ccache
+    - ROS_REPO=ros
+  matrix:
+    - ROS_DISTRO="melodic"
+    - ROS_DISTRO="melodic" ROS_REPO=ros-testing
+
+install:
+  - git clone --quiet --depth=1 https://github.com/ros-industrial/industrial_ci.git .ci_config
+
+script:
+  - .ci_config/travis.sh


### PR DESCRIPTION
As per subject.

Now that the base `rxros` packages have been released, setting up CI for this repository is almost trivial.

I've only enabled Melodic builds for now, as I seem to remember the `brickpi` packages cannot be built successfully on Kinetic.
