### PR TITLE
Fix of issue #9:  RxROS version of VelocityPublisher works erratic

### DIFF
--- a/rxros_teleop/src/VelocityPublisher_rx.cpp
+++ b/rxros_teleop/src/VelocityPublisher_rx.cpp
@@ -77,7 +77,9 @@ int main(int argc, char** argv) {
         else if (event == JS_EVENT_AXIS_LEFT || event == KB_EVENT_LEFT)
             return std::make_tuple(prevVelLinear, adaptVelocity((prevVelAngular + deltaVelAngular), minVelAngular, maxVelAngular, true)); // move left
         else if (event == JS_EVENT_AXIS_RIGHT || event == KB_EVENT_RIGHT)
-            return std::make_tuple(prevVelLinear, adaptVelocity((prevVelAngular - deltaVelAngular), minVelAngular, maxVelAngular, false));}; // move right
+            return std::make_tuple(prevVelLinear, adaptVelocity((prevVelAngular - deltaVelAngular), minVelAngular, maxVelAngular, false)); // move right
+        else
+            return std::make_tuple(prevVelLinear, prevVelAngular);}; // do nothing    
 
     auto velTuple2TwistMsg = [](auto velTuple) {
         geometry_msgs::Twist vel;


### PR DESCRIPTION
A else statement have been added to the teleop2VelTuple function that returns the current (previous) linear and angular velocity in case the joystick or keyboard has not been touched/pressed. This situation typically happens when the joystick or key press is released. 